### PR TITLE
feat: revamp bill AI Q&A into persistent follow-up chat

### DIFF
--- a/Documentation/overview.md
+++ b/Documentation/overview.md
@@ -118,6 +118,99 @@ For performance, analytics data is precomputed during sync:
 | `congressPolicyAreas` | Bills grouped by policy area |
 | `congressSponsors` | Bills grouped by sponsor |
 | `syncSnapshots` | Audit trail for sync runs |
+| `billChats` | Per-bill chat sessions keyed by (billId, sessionId) |
+| `billChatMessages` | Individual chat turns (user + assistant) |
+
+---
+
+# Bill Chat Feature
+
+## Overview
+
+Each bill detail page includes a full **chat panel** powered by the NVIDIA Nemotron model via OpenRouter. Users can ask questions in natural language and have a multi-turn conversation — follow-up questions have full context from prior turns.
+
+## Architecture
+
+```
+User types question (components/bills/bill-qa.tsx)
+    ↓
+billsService.sendChatMessage(billId, sessionId, question)
+    ↓
+Convex action: api.llm.sendChatMessage
+    ↓
+  1. Get/create billChats row for (billId, sessionId)
+  2. Fetch prior turns from billChatMessages
+  3. Save user message to billChatMessages
+  4. Call OpenRouter API with:
+       - system prompt (bill context)
+       - full conversation history
+       - current user question
+  5. Save assistant response to billChatMessages
+    ↓
+Answer rendered as Markdown in the chat UI
+```
+
+## Session Persistence
+
+Chat history is persisted per user **browser session** using an anonymous `sessionId` stored in `localStorage` (`bill_chat_session_id`). On every visit to a bill page the component:
+
+1. Reads the session ID from `localStorage` (or creates one on first visit)
+2. Queries `getBillChatHistory(billId, sessionId)` to restore prior messages
+3. Displays the conversation thread; new messages are appended in real-time
+
+Each browser retains its own private history per bill — there is no shared global chat.
+
+## Convex Functions (`convex/llm.ts`)
+
+| Function | Type | Purpose |
+|----------|------|---------|
+| `getBillChatHistory` | public query | Fetch chat history for a (billId, sessionId) |
+| `sendChatMessage` | public action | Send a message and get AI response (persists both turns) |
+| `getOrCreateBillChat` | internal mutation | Get or create a chat session row |
+| `addChatMessage` | internal mutation | Append a message to a session |
+| `getMessagesForChat` | internal query | Read all messages for a session |
+| `askBillQuestion` | public action (legacy) | Single-turn Q&A (kept for backward compat) |
+
+## Database Tables
+
+### `billChats`
+One row per (billId × sessionId) pair:
+```typescript
+{ billId: string, sessionId: string, createdAt: string }
+```
+
+### `billChatMessages`
+One row per message turn:
+```typescript
+{ chatId: Id<"billChats">, role: "user" | "assistant", content: string, createdAt: string }
+```
+
+## LLM Prompt Strategy
+
+The conversation history is passed to OpenRouter using the standard `messages` array format:
+
+```
+[system]   → bill metadata + instructions (rebuilt each request)
+[user]     → first question
+[assistant]→ first answer
+[user]     → follow-up
+...
+[user]     → current question
+```
+
+This gives the model full context for coherent multi-turn answers.
+
+## Testing the Chat Feature
+
+1. Visit any bill detail page, e.g. `/bills/1hr119`
+2. The chat panel is at the bottom — ask any question using the example chips or free text
+3. Ask a follow-up that references the first answer (e.g. "Tell me more about that") — the model should maintain context
+4. Reload the page — history should be restored from Convex
+5. Open the same bill in a different browser/incognito — history should be empty (different session)
+
+To inspect persisted chats in Convex dashboard:
+- Table: `billChats` — one row per user session + bill
+- Table: `billChatMessages` — all turns in order
 
 ---
 
@@ -150,6 +243,14 @@ For performance, analytics data is precomputed during sync:
 | `recomputeCongressPolicyAreas` | Recompute policy areas |
 | `recomputeCongressSponsors` | Recompute sponsors |
 | `deleteCongressBills` | Delete all bills for a specific Congress |
+
+## AI Chat (`convex/llm.ts`)
+
+| Function | Type | Purpose |
+|----------|------|---------|
+| `getBillChatHistory` | public query | Return persisted messages for a (billId, sessionId) |
+| `sendChatMessage` | public action | Multi-turn chat with persistence |
+| `askBillQuestion` | public action | Legacy single-turn Q&A |
 
 ## API Integration (`convex/congressApi.ts`)
 
@@ -285,11 +386,11 @@ CONGRESS_API_KEY=      # Get from https://api.congress.gov/sign-up/
 ## Optional
 
 ```env
+# AI Bill Chat (required for chat feature)
+OPENROUTER_API_KEY=   # Get from https://openrouter.ai/
+
 # Analytics (if using Vercel)
 NEXT_PUBLIC_ANALYTICS_ID=
-
-# Development
-DEBUG=false
 ```
 
 ---

--- a/Documentation/overview.md
+++ b/Documentation/overview.md
@@ -375,13 +375,15 @@ See `interactive-dashboard.md` for detailed walkthrough.
 ## Required
 
 ```env
-# Convex (created automatically by `npx convex dev`)
-CONVEX_DEPLOYMENT=
-NEXT_PUBLIC_CONVEX_URL=
+# Production Convex only for this repo
+CONVEX_DEPLOYMENT=prod:industrious-llama-331
+NEXT_PUBLIC_CONVEX_URL=https://industrious-llama-331.convex.cloud
 
 # Congress.gov API
 CONGRESS_API_KEY=      # Get from https://api.congress.gov/sign-up/
 ```
+
+Do not use `npx convex dev` for this project. Local frontend development should still point at the production Convex deployment.
 
 ## Optional
 

--- a/app/ConvexClientProvider.tsx
+++ b/app/ConvexClientProvider.tsx
@@ -1,17 +1,34 @@
 "use client";
 
 import { ConvexProvider, ConvexReactClient } from "convex/react";
-import { ReactNode } from "react";
+import { createContext, ReactNode, useContext } from "react";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
 
-// Create client only if CONVEX_URL is configured
 const convex = convexUrl ? new ConvexReactClient(convexUrl) : null;
+
+const ConvexEnabledContext = createContext(false);
+
+/**
+ * Returns true when Convex is configured and the ConvexProvider is active.
+ * Components that call Convex hooks (useQuery, useMutation, etc.) must
+ * gate on this to avoid the "missing provider" runtime error.
+ */
+export function useConvexEnabled() {
+  return useContext(ConvexEnabledContext);
+}
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   if (!convex) {
-    // Convex not configured yet - render children without provider
-    return <>{children}</>;
+    return (
+      <ConvexEnabledContext.Provider value={false}>
+        {children}
+      </ConvexEnabledContext.Provider>
+    );
   }
-  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+  return (
+    <ConvexEnabledContext.Provider value={true}>
+      <ConvexProvider client={convex}>{children}</ConvexProvider>
+    </ConvexEnabledContext.Provider>
+  );
 }

--- a/app/components/dashboard/DashboardClient.tsx
+++ b/app/components/dashboard/DashboardClient.tsx
@@ -4,15 +4,46 @@ import { useState, useEffect } from 'react';
 import { useQuery } from 'convex/react';
 import { api } from '../../../convex/_generated/api';
 import { useRouter } from 'next/navigation';
+import { useConvexEnabled } from '../../ConvexClientProvider';
 
 interface DashboardProps {
   initialCongress?: number;
 }
 
 export default function Dashboard({ initialCongress = 119 }: DashboardProps) {
+  const convexEnabled = useConvexEnabled();
+
+  if (!convexEnabled) {
+    return <ConvexNotConfigured />;
+  }
+
+  return <DashboardInner initialCongress={initialCongress} />;
+}
+
+function ConvexNotConfigured() {
+  return (
+    <div className="min-h-screen bg-congress-navy-950 text-white flex items-center justify-center">
+      <div className="max-w-md text-center p-8">
+        <h2 className="text-2xl font-bold mb-4">Convex Not Configured</h2>
+        <p className="text-congress-navy-300 mb-4">
+          The real-time dashboard requires a Convex backend. Set the{' '}
+          <code className="bg-congress-navy-800 px-1.5 py-0.5 rounded text-sm">
+            NEXT_PUBLIC_CONVEX_URL
+          </code>{' '}
+          environment variable and restart the dev server.
+        </p>
+        <p className="text-congress-navy-400 text-sm">
+          See the project README for setup instructions.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function DashboardInner({ initialCongress = 119 }: DashboardProps) {
   const router = useRouter();
   const [selectedCongress, setSelectedCongress] = useState(initialCongress);
-  
+
   const allCongressData = useQuery(api.bills.getAllCongressOverview);
   const congressDashboard = useQuery(api.bills.getCongressDashboard, { congress: selectedCongress });
 

--- a/components/bills/bill-qa.tsx
+++ b/components/bills/bill-qa.tsx
@@ -1,8 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { billsService } from '@/lib/services/bills-service';
 import ReactMarkdown from 'react-markdown';
+
+interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
 
 interface BillQAProps {
   billId: string;
@@ -15,114 +21,276 @@ const EXAMPLE_QUESTIONS = [
   "What are the key sections of this bill?",
 ];
 
+function generateSessionId(): string {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+function getOrCreateSessionId(): string {
+  if (typeof window === 'undefined') return '';
+  const key = 'bill_chat_session_id';
+  let id = localStorage.getItem(key);
+  if (!id) {
+    id = generateSessionId();
+    localStorage.setItem(key, id);
+  }
+  return id;
+}
+
+const MarkdownMessage = ({ content }: { content: string }) => (
+  <ReactMarkdown
+    components={{
+      p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+      ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
+      ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
+      li: ({ children }) => <li className="ml-1">{children}</li>,
+      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      em: ({ children }) => <em className="italic">{children}</em>,
+      h1: ({ children }) => <h1 className="text-base font-bold mt-3 mb-1">{children}</h1>,
+      h2: ({ children }) => <h2 className="text-sm font-semibold mt-2 mb-1">{children}</h2>,
+      h3: ({ children }) => <h3 className="text-sm font-medium mt-2 mb-1">{children}</h3>,
+      a: ({ href, children }) => (
+        <a
+          href={href}
+          className="text-primary underline underline-offset-2"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {children}
+        </a>
+      ),
+    }}
+  >
+    {content}
+  </ReactMarkdown>
+);
+
+const TypingIndicator = () => (
+  <div className="flex justify-start">
+    <div className="bg-muted rounded-2xl rounded-bl-sm px-4 py-3 flex items-center gap-1.5">
+      <span
+        className="w-2 h-2 rounded-full bg-muted-foreground/60 animate-bounce"
+        style={{ animationDelay: '0ms' }}
+      />
+      <span
+        className="w-2 h-2 rounded-full bg-muted-foreground/60 animate-bounce"
+        style={{ animationDelay: '160ms' }}
+      />
+      <span
+        className="w-2 h-2 rounded-full bg-muted-foreground/60 animate-bounce"
+        style={{ animationDelay: '320ms' }}
+      />
+    </div>
+  </div>
+);
+
 export default function BillQA({ billId }: BillQAProps) {
-  const [question, setQuestion] = useState('');
-  const [answer, setAnswer] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
   const [error, setError] = useState('');
+  const [sessionId, setSessionId] = useState('');
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!question.trim()) return;
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    setIsLoading(true);
-    setError('');
-    setAnswer('');
+  // Initialise session and load persisted history on mount
+  useEffect(() => {
+    const sid = getOrCreateSessionId();
+    setSessionId(sid);
 
-    try {
-      const result = await billsService.askBillQuestion(billId, question);
-      if (result.error) {
-        setError(result.error);
-      } else {
-        setAnswer(result.answer);
-      }
-    } catch (err) {
-      setError('Failed to get response. Please try again.');
-    } finally {
-      setIsLoading(false);
+    billsService
+      .getBillChatHistory(billId, sid)
+      .then((history) => {
+        setMessages(
+          history.map((m) => ({
+            id: m._id,
+            role: m.role,
+            content: m.content,
+          }))
+        );
+      })
+      .catch(() => {
+        // History fetch failure is non-fatal — start fresh
+      })
+      .finally(() => setIsLoadingHistory(false));
+  }, [billId]);
+
+  // Scroll to the latest message
+  useEffect(() => {
+    if (!isLoadingHistory) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  };
+  }, [messages, isLoadingHistory]);
 
-  const handleExampleClick = (example: string) => {
-    setQuestion(example);
-  };
+  const handleSubmit = useCallback(
+    async (question: string) => {
+      const q = question.trim();
+      if (!q || isLoading || !sessionId) return;
+
+      const tempId = `temp_${Date.now()}`;
+      setMessages((prev) => [...prev, { id: tempId, role: 'user', content: q }]);
+      setInput('');
+      setIsLoading(true);
+      setError('');
+
+      try {
+        const result = await billsService.sendChatMessage(billId, sessionId, q);
+        if (result.error) {
+          setError(result.error);
+          // Remove the optimistic user message on error
+          setMessages((prev) => prev.filter((m) => m.id !== tempId));
+        } else {
+          setMessages((prev) => [
+            ...prev,
+            { id: `assistant_${Date.now()}`, role: 'assistant', content: result.answer },
+          ]);
+        }
+      } catch {
+        setError('Failed to get a response. Please try again.');
+        setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      } finally {
+        setIsLoading(false);
+        inputRef.current?.focus();
+      }
+    },
+    [billId, sessionId, isLoading]
+  );
+
+  const isEmpty = messages.length === 0 && !isLoadingHistory;
+  const questionCount = messages.filter((m) => m.role === 'user').length;
 
   return (
-    <div className="bg-card rounded-lg shadow-lg p-4 sm:p-6 mt-4">
-      <h2 className="text-lg sm:text-xl font-semibold mb-4">Ask about this bill</h2>
-      
-      <form onSubmit={handleSubmit} className="mb-4">
-        <div className="flex flex-col sm:flex-row gap-2">
+    <div className="bg-card rounded-lg shadow-lg mt-4 flex flex-col overflow-hidden" style={{ height: '520px' }}>
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b shrink-0">
+        <div className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
+        <h2 className="text-base font-semibold">Ask about this bill</h2>
+        {questionCount > 0 && (
+          <span className="text-xs text-muted-foreground ml-auto">
+            {questionCount} {questionCount === 1 ? 'question' : 'questions'}
+          </span>
+        )}
+      </div>
+
+      {/* ── Messages ───────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3 min-h-0">
+        {isLoadingHistory ? (
+          <div className="flex justify-center items-center h-full">
+            <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary border-t-transparent" />
+          </div>
+        ) : isEmpty ? (
+          /* Empty state: example questions */
+          <div className="flex flex-col items-center justify-center h-full text-center px-2">
+            <p className="text-sm text-muted-foreground mb-4">
+              Ask any question about this bill. Try one of these:
+            </p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-2 justify-center max-w-lg">
+              {EXAMPLE_QUESTIONS.map((q, i) => (
+                <button
+                  key={i}
+                  onClick={() => handleSubmit(q)}
+                  disabled={isLoading}
+                  className="px-3 py-2 text-sm bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors text-left sm:text-center disabled:opacity-50"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <>
+            {messages.map((message) => (
+              <div
+                key={message.id}
+                className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                    message.role === 'user'
+                      ? 'bg-primary text-primary-foreground rounded-br-sm'
+                      : 'bg-muted text-foreground rounded-bl-sm'
+                  }`}
+                >
+                  {message.role === 'assistant' ? (
+                    <MarkdownMessage content={message.content} />
+                  ) : (
+                    <p>{message.content}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+
+            {isLoading && <TypingIndicator />}
+
+            {/* Example chips shown after first message for quick follow-ups */}
+            {!isLoading && messages.length > 0 && messages.length < 4 && (
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {EXAMPLE_QUESTIONS.filter(
+                  (q) => !messages.some((m) => m.role === 'user' && m.content === q)
+                )
+                  .slice(0, 3)
+                  .map((q, i) => (
+                    <button
+                      key={i}
+                      onClick={() => handleSubmit(q)}
+                      disabled={isLoading}
+                      className="px-2.5 py-1 text-xs bg-secondary text-secondary-foreground rounded-full hover:bg-secondary/80 transition-colors disabled:opacity-50"
+                    >
+                      {q}
+                    </button>
+                  ))}
+              </div>
+            )}
+          </>
+        )}
+
+        {error && (
+          <div className="flex justify-center">
+            <div className="px-3 py-2 bg-destructive/10 border border-destructive/20 rounded-lg max-w-sm text-center">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* ── Input bar ──────────────────────────────────────────────── */}
+      <div className="border-t px-4 py-3 shrink-0">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit(input);
+          }}
+          className="flex gap-2"
+        >
           <input
+            ref={inputRef}
             type="text"
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
-            placeholder="Ask a question about this bill..."
-            className="flex-1 px-4 py-2 rounded-md border border-input bg-background text-sm sm:text-base focus:outline-none focus:ring-2 focus:ring-primary"
-            disabled={isLoading}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={isEmpty ? 'Ask a question about this bill…' : 'Ask a follow-up question…'}
+            className="flex-1 px-3 py-2 text-sm rounded-lg border border-input bg-background focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
+            disabled={isLoading || isLoadingHistory}
+            maxLength={500}
           />
           <button
             type="submit"
-            disabled={isLoading || !question.trim()}
-            className="px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+            disabled={isLoading || isLoadingHistory || !input.trim()}
+            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
           >
-            {isLoading ? 'Thinking...' : 'Ask'}
+            {isLoading ? (
+              <span className="flex items-center gap-1.5">
+                <span className="animate-spin rounded-full h-3.5 w-3.5 border-2 border-primary-foreground border-t-transparent" />
+                <span>Thinking</span>
+              </span>
+            ) : (
+              'Send'
+            )}
           </button>
-        </div>
-      </form>
-
-      <div className="mb-4">
-        <p className="text-xs text-muted-foreground mb-2">Try asking:</p>
-        <div className="flex flex-wrap gap-2">
-          {EXAMPLE_QUESTIONS.map((example, index) => (
-            <button
-              key={index}
-              onClick={() => handleExampleClick(example)}
-              disabled={isLoading}
-              className="px-2 py-1 text-xs sm:text-sm bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/80 transition-colors disabled:opacity-50"
-            >
-              {example}
-            </button>
-          ))}
-        </div>
+        </form>
       </div>
-
-      {isLoading && (
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
-          <span className="text-sm">Analyzing bill and generating response...</span>
-        </div>
-      )}
-
-      {error && (
-        <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-          <p className="text-sm text-destructive">{error}</p>
-        </div>
-      )}
-
-      {answer && (
-        <div className="mt-4 p-4 bg-muted/30 rounded-md">
-          <h3 className="text-sm font-medium mb-2">Answer:</h3>
-          <div className="prose prose-sm max-w-none text-sm sm:text-base leading-relaxed">
-            <ReactMarkdown
-              components={{
-                p: ({ children }) => <p className="mb-2">{children}</p>,
-                ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
-                ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
-                li: ({ children }) => <li>{children}</li>,
-                strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                em: ({ children }) => <em className="italic">{children}</em>,
-                h1: ({ children }) => <h1 className="text-xl font-bold mt-4 mb-2">{children}</h1>,
-                h2: ({ children }) => <h2 className="text-lg font-semibold mt-3 mb-2">{children}</h2>,
-                h3: ({ children }) => <h3 className="text-base font-semibold mt-2 mb-1">{children}</h3>,
-                a: ({ href, children }) => <a href={href} className="text-primary underline" target="_blank" rel="noopener noreferrer">{children}</a>,
-              }}
-            >
-              {answer}
-            </ReactMarkdown>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/convex/llm.ts
+++ b/convex/llm.ts
@@ -1,4 +1,4 @@
-import { action } from "./_generated/server";
+import { action, internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { internal, api } from "./_generated/api";
 import { v } from "convex/values";
 
@@ -25,34 +25,40 @@ interface BillContext {
   actions: Array<{ date: string; description: string }>;
 }
 
-function buildPrompt(bill: BillContext, question: string): string {
-  const stageDescriptions: Record<number, string> = {
-    20: "Introduced",
-    40: "In Committee", 
-    60: "Passed One Chamber",
-    80: "Passed Both Chambers",
-    85: "Vetoed",
-    90: "To President",
-    95: "Signed by President",
-    100: "Became Law",
-  };
+const STAGE_DESCRIPTIONS: Record<number, string> = {
+  20: "Introduced",
+  40: "In Committee",
+  60: "Passed One Chamber",
+  80: "Passed Both Chambers",
+  85: "Vetoed",
+  90: "To President",
+  95: "Signed by President",
+  100: "Became Law",
+};
 
-  const partyNames: Record<string, string> = {
-    R: "Republican",
-    D: "Democrat",
-    I: "Independent",
-  };
+const PARTY_NAMES: Record<string, string> = {
+  R: "Republican",
+  D: "Democrat",
+  I: "Independent",
+};
 
-  const sponsorParty = partyNames[bill.sponsorParty] || bill.sponsorParty;
+function getStageDescription(stage: number): string {
+  return STAGE_DESCRIPTIONS[stage] || "Unknown";
+}
 
-  const context = `# BILL INFORMATION
+/** Build a system prompt containing all bill context for the AI. */
+function buildSystemPrompt(bill: BillContext): string {
+  const sponsorParty = PARTY_NAMES[bill.sponsorParty] || bill.sponsorParty;
+  const stageLabel = STAGE_DESCRIPTIONS[bill.progressStage] || "Unknown";
 
-## Basic Details
+  return `You are a helpful assistant that explains U.S. legislation to regular citizens. You have been given information about a specific bill and will answer questions about it based ONLY on the provided context.
+
+## Bill Information
 - **Bill ID**: ${bill.billId}
 - **Congress**: ${bill.congress}th Congress
 - **Bill Type**: ${bill.billTypeLabel} ${bill.billNumber}
 - **Title**: ${bill.title}
-- **Introduced Date**: ${bill.introducedDate}
+- **Introduced**: ${bill.introducedDate}
 - **Policy Area**: ${bill.policyArea || "Not specified"}
 
 ## Sponsor
@@ -61,41 +67,115 @@ function buildPrompt(bill: BillContext, question: string): string {
 - **State**: ${bill.sponsorState}
 
 ## Current Status
-- **Stage**: ${bill.progressDescription} (${stageDescriptions[bill.progressStage] || "Unknown"})
-- **Progress**: ${bill.progressStage}/100
+- **Stage**: ${bill.progressDescription} (${stageLabel}, ${bill.progressStage}/100)
 
 ## Official Summary
 ${bill.summary || "No official summary available."}
 
-## Legislative History (Recent Actions)
+## Recent Legislative Actions
 ${bill.actions.slice(0, 10).map((a, i) => `${i + 1}. [${a.date}] ${a.description}`).join("\n") || "No actions recorded."}
 
-# USER QUESTION
-${question}
-
-# INSTRUCTIONS
-You are a helpful assistant that explains U.S. legislation to regular citizens. 
-Answer the user's question based ONLY on the bill information provided above.
-- Be clear, accurate, and easy to understand
-- If you're unsure about something, say so
-- Use plain language - avoid legal jargon where possible
+## Instructions
+- Answer questions based ONLY on the bill information provided above
+- Be clear, accurate, and easy to understand; use plain language
+- Avoid legal jargon where possible; define terms if needed
 - Cite specific details from the bill when relevant
-- Keep your answer concise but informative (2-4 paragraphs max unless the question requires more detail)
-- Note: This database only includes the primary sponsor. Check the bill text for any co-sponsors that may be listed.
-
-# ANSWER
-`;
-
-  return context;
+- Keep answers concise but informative (2–4 paragraphs unless more detail is needed)
+- This database only includes the primary sponsor; check the bill text for co-sponsors
+- Use the conversation history to maintain context for follow-up questions`;
 }
 
-export const askBillQuestion = action({
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+/** Get or create a chat session for a (billId, sessionId) pair. */
+export const getOrCreateBillChat = internalMutation({
+  args: { billId: v.string(), sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("billChats")
+      .withIndex("by_billId_and_session", (q) =>
+        q.eq("billId", args.billId).eq("sessionId", args.sessionId)
+      )
+      .first();
+    if (existing) return existing._id;
+    return await ctx.db.insert("billChats", {
+      billId: args.billId,
+      sessionId: args.sessionId,
+      createdAt: new Date().toISOString(),
+    });
+  },
+});
+
+/** Append a message to an existing chat session. */
+export const addChatMessage = internalMutation({
+  args: {
+    chatId: v.id("billChats"),
+    role: v.union(v.literal("user"), v.literal("assistant")),
+    content: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("billChatMessages", {
+      chatId: args.chatId,
+      role: args.role,
+      content: args.content,
+      createdAt: new Date().toISOString(),
+    });
+  },
+});
+
+/** Fetch all messages for a chat session in chronological order. */
+export const getMessagesForChat = internalQuery({
+  args: { chatId: v.id("billChats") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("billChatMessages")
+      .withIndex("by_chatId", (q) => q.eq("chatId", args.chatId))
+      .order("asc")
+      .collect();
+  },
+});
+
+// ─── Public queries ───────────────────────────────────────────────────────────
+
+/**
+ * Fetch persisted chat history for a given bill + browser session.
+ * Returns an empty array when no chat exists yet.
+ */
+export const getBillChatHistory = query({
+  args: { billId: v.string(), sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const chat = await ctx.db
+      .query("billChats")
+      .withIndex("by_billId_and_session", (q) =>
+        q.eq("billId", args.billId).eq("sessionId", args.sessionId)
+      )
+      .first();
+    if (!chat) return [];
+    return await ctx.db
+      .query("billChatMessages")
+      .withIndex("by_chatId", (q) => q.eq("chatId", chat._id))
+      .order("asc")
+      .collect();
+  },
+});
+
+// ─── Public actions ───────────────────────────────────────────────────────────
+
+/**
+ * Send a chat message about a bill and return the AI response.
+ *
+ * - Persists the full conversation (user + assistant turns) in Convex so
+ *   returning visitors pick up where they left off.
+ * - Passes prior turns as OpenRouter `messages` for proper multi-turn context.
+ */
+export const sendChatMessage = action({
   args: {
     billId: v.string(),
+    sessionId: v.string(),
     question: v.string(),
   },
   handler: async (ctx, args): Promise<{ answer: string; error?: string }> => {
-    const { billId, question } = args;
+    const { billId, sessionId, question } = args;
 
     const apiKey = process.env.OPENROUTER_API_KEY;
     if (!apiKey) {
@@ -103,11 +183,9 @@ export const askBillQuestion = action({
     }
 
     try {
+      // Fetch bill data
       const bill = await ctx.runQuery(api.bills.getById, { billId });
-
-      if (!bill) {
-        return { answer: "", error: "Bill not found." };
-      }
+      if (!bill) return { answer: "", error: "Bill not found." };
 
       const actions = await ctx.runQuery(internal.bills.getBillActions, { billId });
 
@@ -131,24 +209,42 @@ export const askBillQuestion = action({
         actions: actions || [],
       };
 
-      const prompt = buildPrompt(billContext, question);
+      // Get or create chat session
+      const chatId = await ctx.runMutation(internal.llm.getOrCreateBillChat, {
+        billId,
+        sessionId,
+      });
 
+      // Fetch existing conversation history (before this turn)
+      const history = await ctx.runQuery(internal.llm.getMessagesForChat, { chatId });
+
+      // Persist user message
+      await ctx.runMutation(internal.llm.addChatMessage, {
+        chatId,
+        role: "user",
+        content: question,
+      });
+
+      // Build messages array: system prompt + full history + current question
+      const systemPrompt = buildSystemPrompt(billContext);
+      const llmMessages = [
+        { role: "system", content: systemPrompt },
+        ...history.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
+        { role: "user", content: question },
+      ];
+
+      // Call OpenRouter
       const response = await fetch(OPENROUTER_API_URL, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${apiKey}`,
+          Authorization: `Bearer ${apiKey}`,
           "HTTP-Referer": "https://billsincongress.com",
           "X-Title": "BillsInCongress",
         },
         body: JSON.stringify({
           model: MODEL,
-          messages: [
-            {
-              role: "user",
-              content: prompt,
-            },
-          ],
+          messages: llmMessages,
           max_tokens: 2048,
           temperature: 0.3,
         }),
@@ -163,25 +259,97 @@ export const askBillQuestion = action({
       const data = await response.json();
       const answer = data.choices?.[0]?.message?.content || "No response generated.";
 
-      return { answer };
+      // Persist assistant response
+      await ctx.runMutation(internal.llm.addChatMessage, {
+        chatId,
+        role: "assistant",
+        content: answer,
+      });
 
+      return { answer };
+    } catch (error) {
+      console.error("Error in sendChatMessage:", error);
+      return { answer: "", error: "An unexpected error occurred." };
+    }
+  },
+});
+
+/**
+ * Legacy single-turn Q&A action — kept for backward compatibility.
+ * New code should use `sendChatMessage` instead.
+ */
+export const askBillQuestion = action({
+  args: {
+    billId: v.string(),
+    question: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ answer: string; error?: string }> => {
+    const { billId, question } = args;
+
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      return { answer: "", error: "OpenRouter API key not configured." };
+    }
+
+    try {
+      const bill = await ctx.runQuery(api.bills.getById, { billId });
+      if (!bill) return { answer: "", error: "Bill not found." };
+
+      const actions = await ctx.runQuery(internal.bills.getBillActions, { billId });
+
+      const billContext: BillContext = {
+        billId: bill.billId || "",
+        congress: bill.congress || 119,
+        billType: bill.billType || "",
+        billNumber: bill.billNumber || "",
+        billTypeLabel: bill.billTypeLabel || "",
+        title: bill.title || "",
+        introducedDate: bill.introducedDate || "",
+        sponsorFirstName: bill.sponsorFirstName || "",
+        sponsorLastName: bill.sponsorLastName || "",
+        sponsorParty: bill.sponsorParty || "",
+        sponsorState: bill.sponsorState || "",
+        progressStage: bill.progressStage || 20,
+        progressDescription: getStageDescription(bill.progressStage || 20),
+        policyArea: bill.bill_subjects?.policy_area_name || "",
+        summary: bill.latest_summary || "",
+        pdfUrl: bill.pdf_url || "",
+        actions: actions || [],
+      };
+
+      const systemPrompt = buildSystemPrompt(billContext);
+
+      const response = await fetch(OPENROUTER_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "HTTP-Referer": "https://billsincongress.com",
+          "X-Title": "BillsInCongress",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: question },
+          ],
+          max_tokens: 2048,
+          temperature: 0.3,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("OpenRouter API error:", errorText);
+        return { answer: "", error: "Failed to get response from AI." };
+      }
+
+      const data = await response.json();
+      const answer = data.choices?.[0]?.message?.content || "No response generated.";
+      return { answer };
     } catch (error) {
       console.error("Error in askBillQuestion:", error);
       return { answer: "", error: "An unexpected error occurred." };
     }
   },
 });
-
-function getStageDescription(stage: number): string {
-  const descriptions: Record<number, string> = {
-    20: "Introduced",
-    40: "In Committee",
-    60: "Passed One Chamber",
-    80: "Passed Both Chambers",
-    85: "Vetoed",
-    90: "To President",
-    95: "Signed by President",
-    100: "Became Law",
-  };
-  return descriptions[stage] || "Unknown";
-}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -123,6 +123,21 @@ export default defineSchema({
     .index("by_congress", ["congress"])
     .index("by_congress_and_count", ["congress", "billCount"]),
 
+  // Bill chat sessions — one per (billId, sessionId) pair
+  billChats: defineTable({
+    billId: v.string(),
+    sessionId: v.string(), // anonymous session ID stored in browser localStorage
+    createdAt: v.string(),
+  }).index("by_billId_and_session", ["billId", "sessionId"]),
+
+  // Bill chat messages — individual turns in a chat session
+  billChatMessages: defineTable({
+    chatId: v.id("billChats"),
+    role: v.union(v.literal("user"), v.literal("assistant")),
+    content: v.string(),
+    createdAt: v.string(),
+  }).index("by_chatId", ["chatId"]),
+
   // Sync snapshots for audit trail
   syncSnapshots: defineTable({
     syncType: v.string(), // "historical" or "daily"

--- a/lib/services/bills-service.ts
+++ b/lib/services/bills-service.ts
@@ -187,4 +187,48 @@ export const billsService = {
       return { answer: "", error: "Failed to get response" };
     }
   },
+
+  /**
+   * Fetch persisted chat history for a bill + anonymous browser session.
+   * Returns an empty array when no conversation exists yet.
+   */
+  async getBillChatHistory(
+    billId: string,
+    sessionId: string
+  ): Promise<Array<{ _id: string; role: 'user' | 'assistant'; content: string; createdAt: string }>> {
+    const client = getConvexClient();
+    if (!client) return [];
+
+    try {
+      const { api } = await import('../../convex/_generated/api');
+      const result = await client.query(api.llm.getBillChatHistory, { billId, sessionId });
+      return result as Array<{ _id: string; role: 'user' | 'assistant'; content: string; createdAt: string }>;
+    } catch (error) {
+      console.error('Error fetching bill chat history:', error);
+      return [];
+    }
+  },
+
+  /**
+   * Send a message in the bill chat and return the AI response.
+   * Persists both the user message and the assistant reply in Convex.
+   */
+  async sendChatMessage(
+    billId: string,
+    sessionId: string,
+    question: string
+  ): Promise<{ answer: string; error?: string }> {
+    const client = getConvexClient();
+    if (!client) {
+      return { answer: "", error: "Service not available" };
+    }
+
+    try {
+      const { api } = await import('../../convex/_generated/api');
+      return await client.action(api.llm.sendChatMessage, { billId, sessionId, question });
+    } catch (error) {
+      console.error('Error sending chat message:', error);
+      return { answer: "", error: "Failed to get response" };
+    }
+  },
 };


### PR DESCRIPTION
## Summary
- replace the single-turn bill Q&A box with a persistent multi-turn chat experience
- store bill chat sessions/messages in Convex so follow-up questions keep context
- update the bill chat prompt/service/docs to support conversational bill analysis while keeping Convex production-only

## Testing
- npm run build
