### PR TITLE
fix: remove 10K bill cap on homepage stats with @convex-dev/aggregate

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,9 +8,12 @@
  * @module
  */
 
+import type * as aggregateBackfill from "../aggregateBackfill.js";
+import type * as aggregates from "../aggregates.js";
 import type * as bills from "../bills.js";
 import type * as congressApi from "../congressApi.js";
 import type * as crons from "../crons.js";
+import type * as functions from "../functions.js";
 import type * as llm from "../llm.js";
 import type * as mutations from "../mutations.js";
 import type * as sync from "../sync.js";
@@ -22,9 +25,12 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  aggregateBackfill: typeof aggregateBackfill;
+  aggregates: typeof aggregates;
   bills: typeof bills;
   congressApi: typeof congressApi;
   crons: typeof crons;
+  functions: typeof functions;
   llm: typeof llm;
   mutations: typeof mutations;
   sync: typeof sync;

--- a/convex/aggregateBackfill.ts
+++ b/convex/aggregateBackfill.ts
@@ -1,0 +1,146 @@
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import { internalAction, internalQuery } from "./_generated/server";
+import { internalMutation } from "./functions";
+import { billsByChamber, billsByStage } from "./aggregates";
+
+const BACKFILL_BATCH_SIZE = 500;
+
+/**
+ * Public action to backfill the bill aggregates from the existing `bills`
+ * table. Run this once after deploying the aggregate components — without it
+ * the new `recomputeCongressStats` would see empty aggregates.
+ *
+ * Idempotent: uses `insertIfDoesNotExist` so re-running on already-populated
+ * aggregates is safe.
+ *
+ *     npx convex run --prod aggregateBackfill:run '{}'
+ *
+ * The action only kicks off the first batch and returns immediately. Each
+ * batch self-schedules the next via the scheduler so we never exceed Convex's
+ * per-mutation document limit, and the final batch triggers a recompute of
+ * every congressStats row.
+ */
+export const run = internalAction({
+  args: {},
+  handler: async (ctx): Promise<{ started: true }> => {
+    console.log("Starting aggregate backfill from null cursor");
+    await ctx.scheduler.runAfter(
+      0,
+      internal.aggregateBackfill.backfillBatch,
+      { cursor: null },
+    );
+    return { started: true };
+  },
+});
+
+/**
+ * Process one page of bills and self-schedule the next page.
+ */
+export const backfillBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const numItems = args.batchSize ?? BACKFILL_BATCH_SIZE;
+    const result = await ctx.db.query("bills").paginate({
+      cursor: args.cursor,
+      numItems,
+    });
+
+    for (const bill of result.page) {
+      // Idempotent so we don't blow up if the aggregate already has the doc
+      // (e.g. when a sync ran between batches and the trigger inserted it).
+      await billsByChamber.insertIfDoesNotExist(ctx, bill);
+      await billsByStage.insertIfDoesNotExist(ctx, bill);
+    }
+
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.aggregateBackfill.backfillBatch,
+        { cursor: result.continueCursor, batchSize: numItems },
+      );
+      return;
+    }
+
+    console.log(
+      "Aggregate backfill complete — recomputing congressStats for all known congresses",
+    );
+    await ctx.scheduler.runAfter(
+      0,
+      internal.aggregateBackfill.recomputeAll,
+      {},
+    );
+  },
+});
+
+/**
+ * After the backfill finishes, refresh `congressStats` for every congress
+ * that has bills so the homepage cache reflects the now-correct aggregate
+ * values.
+ */
+export const recomputeAll = internalAction({
+  args: {},
+  handler: async (ctx): Promise<{ congresses: number[] }> => {
+    const congresses: number[] = await ctx.runQuery(
+      internal.aggregateBackfill.distinctCongresses,
+      {},
+    );
+    for (const congress of congresses) {
+      await ctx.runMutation(internal.mutations.recomputeCongressStats, {
+        congress,
+      });
+    }
+    console.log(
+      `Recomputed congressStats for: ${congresses.join(", ") || "(none)"}`,
+    );
+    return { congresses };
+  },
+});
+
+/**
+ * Returns every distinct `congress` that appears in the bills table. Used by
+ * the post-backfill recompute step. Probes a fixed range so we don't have to
+ * scan the bills table — historical sync only writes congresses 93-120.
+ */
+export const distinctCongresses = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<number[]> => {
+    const present: number[] = [];
+    for (let c = 93; c <= 130; c++) {
+      const first = await ctx.db
+        .query("bills")
+        .withIndex("by_congress", (q) => q.eq("congress", c))
+        .first();
+      if (first) present.push(c);
+    }
+    return present;
+  },
+});
+
+/**
+ * Wipes both bill aggregates. Use only if you intend to immediately re-run
+ * the backfill. After clearing, you MUST run `aggregateBackfill:run` before
+ * `recomputeCongressStats` runs again, or the precomputed stats will get
+ * zeroed out (the recompute has a guard to avoid this, but it relies on the
+ * bills table being non-empty).
+ *
+ *     npx convex run --prod aggregateBackfill:clear '{}'
+ */
+export const clear = internalAction({
+  args: {},
+  handler: async (ctx): Promise<{ cleared: true }> => {
+    await ctx.runMutation(internal.aggregateBackfill.clearAggregates, {});
+    return { cleared: true };
+  },
+});
+
+export const clearAggregates = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    await billsByChamber.clearAll(ctx);
+    await billsByStage.clearAll(ctx);
+  },
+});

--- a/convex/aggregates.ts
+++ b/convex/aggregates.ts
@@ -1,0 +1,71 @@
+import { TableAggregate } from "@convex-dev/aggregate";
+import { componentsGeneric } from "convex/server";
+import { DataModel } from "./_generated/dataModel";
+
+// Component handles. We resolve them via `componentsGeneric()` rather than the
+// `_generated/api.ts` re-export so this file typechecks locally without
+// requiring `npx convex codegen` to run with credentials. After
+// `convex deploy` runs codegen, both forms refer to the same object.
+const components = componentsGeneric() as unknown as {
+  billsByChamber: any;
+  billsByStage: any;
+};
+
+const DEFAULT_STAGE = 20; // "Introduced" — used when progressStage is missing
+
+/**
+ * Aggregate over the `bills` table partitioned by `congress`, sorted by
+ * `billType`. Lets us compute totalCount/houseCount/senateCount per congress
+ * in O(log n) without scanning the table.
+ *
+ * House bill types start with "h" (hr, hjres, hconres, hres) and Senate bill
+ * types start with "s" (s, sjres, sconres, sres). We use `prefix: ["h"]` and
+ * `prefix: ["s"]` ranges via lexicographic bounds to slice the aggregate.
+ */
+export const billsByChamber = new TableAggregate<{
+  Namespace: number;
+  Key: string;
+  DataModel: DataModel;
+  TableName: "bills";
+}>(components.billsByChamber, {
+  namespace: (doc) => doc.congress,
+  sortKey: (doc) => doc.billType,
+});
+
+/**
+ * Aggregate over the `bills` table partitioned by `congress`, sorted by
+ * `progressStage`. Lets us compute the per-stage breakdown for the homepage
+ * status chart in O(log n).
+ */
+export const billsByStage = new TableAggregate<{
+  Namespace: number;
+  Key: number;
+  DataModel: DataModel;
+  TableName: "bills";
+}>(components.billsByStage, {
+  namespace: (doc) => doc.congress,
+  sortKey: (doc) => doc.progressStage ?? DEFAULT_STAGE,
+});
+
+/**
+ * Bill stages that appear on the homepage status chart. Order matters here —
+ * it controls the sort order of the chart segments.
+ */
+export const BILL_STAGES: ReadonlyArray<{ stage: number; description: string }> =
+  [
+    { stage: 20, description: "Introduced" },
+    { stage: 40, description: "In Committee" },
+    { stage: 60, description: "Passed One Chamber" },
+    { stage: 80, description: "Passed Both Chambers" },
+    { stage: 85, description: "Vetoed" },
+    { stage: 90, description: "To President" },
+    { stage: 95, description: "Signed by President" },
+    { stage: 100, description: "Became Law" },
+  ];
+
+/**
+ * Bill type prefixes for each chamber. Used to derive house/senate counts
+ * from `billsByChamber` via lexicographic prefix bounds.
+ */
+export const HOUSE_BILL_TYPES = ["hr", "hjres", "hconres", "hres"] as const;
+export const SENATE_BILL_TYPES = ["s", "sjres", "sconres", "sres"] as const;

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,0 +1,15 @@
+import { defineApp } from "convex/server";
+import aggregate from "@convex-dev/aggregate/convex.config.js";
+
+const app = defineApp();
+
+// Aggregate of bills keyed by [billType] within each congress namespace.
+// Used to compute totalCount, houseCount, and senateCount per congress without
+// scanning the bills table (which can exceed Convex's per-query document limit).
+app.use(aggregate, { name: "billsByChamber" });
+
+// Aggregate of bills keyed by [progressStage] within each congress namespace.
+// Used to compute the per-stage breakdown for the homepage status chart.
+app.use(aggregate, { name: "billsByStage" });
+
+export default app;

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -1,0 +1,35 @@
+import { Triggers } from "convex-helpers/server/triggers";
+import {
+  customCtx,
+  customMutation,
+} from "convex-helpers/server/customFunctions";
+import { DataModel } from "./_generated/dataModel";
+import {
+  internalMutation as rawInternalMutation,
+  mutation as rawMutation,
+} from "./_generated/server";
+import { billsByChamber, billsByStage } from "./aggregates";
+
+/**
+ * Triggers that keep the bill aggregates in sync with the `bills` table.
+ *
+ * Any mutation that uses `internalMutation` / `mutation` from this module
+ * (rather than directly from `_generated/server`) will run these triggers
+ * transactionally on every insert / patch / replace / delete to `bills`.
+ */
+const triggers = new Triggers<DataModel>();
+
+triggers.register("bills", billsByChamber.trigger());
+triggers.register("bills", billsByStage.trigger());
+
+/** Drop-in replacement for `internalMutation` that fires bill triggers. */
+export const internalMutation = customMutation(
+  rawInternalMutation,
+  customCtx(triggers.wrapDB),
+);
+
+/** Drop-in replacement for `mutation` that fires bill triggers. */
+export const mutation = customMutation(
+  rawMutation,
+  customCtx(triggers.wrapDB),
+);

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -1,5 +1,6 @@
-import { internalMutation } from "./_generated/server";
+import { internalMutation } from "./functions";
 import { v } from "convex/values";
+import { billsByChamber, billsByStage, BILL_STAGES } from "./aggregates";
 
 /**
  * Upsert a bill record. If a bill with the same billId exists, update it.
@@ -226,62 +227,74 @@ export const updateBillSyncStatus = internalMutation({
   },
 });
 
-// Bill stage descriptions for stats computation
-const BILL_STAGE_DESCRIPTIONS: Record<number, string> = {
-  20: "Introduced",
-  40: "In Committee",
-  60: "Passed One Chamber",
-  80: "Passed Both Chambers",
-  85: "Vetoed",
-  90: "To President",
-  95: "Signed by President",
-  100: "Became Law",
-};
-
 /**
  * Recompute the congressStats row for a single congress.
- * Scans all bills for that congress (within Convex limits per-congress) and upserts the stats.
+ *
+ * Reads counts from the `billsByChamber` and `billsByStage` aggregate
+ * components instead of scanning the bills table. This is O(log n) and works
+ * regardless of how many bills the congress has — historically this used
+ * `.take(10000)` and silently truncated counts at 10,000 (Congress 118 alone
+ * has 19,314 bills).
+ *
+ * Safety guard: if the aggregates report zero bills for a congress that
+ * actually has bills (e.g. immediately after deploy, before
+ * `aggregateBackfill:run` has populated them), skip the write so we don't
+ * overwrite valid `congressStats` rows with zeros.
  */
 export const recomputeCongressStats = internalMutation({
   args: { congress: v.number() },
   handler: async (ctx, args) => {
-    const bills = await ctx.db
-      .query("bills")
-      .withIndex("by_congress", (q) => q.eq("congress", args.congress))
-      .take(10000);
+    const ns = { namespace: args.congress };
 
-    let houseCount = 0;
-    let senateCount = 0;
-    const stageMap = new Map<number, { description: string; count: number }>();
+    // Lexicographic bounds: every bill type starting with "h" sorts in
+    // ["h", "i") and every "s" type in ["s", "t"). All current bill types are
+    // covered by these two ranges (hr, hjres, hconres, hres / s, sjres,
+    // sconres, sres).
+    const houseBounds = {
+      lower: { key: "h", inclusive: true },
+      upper: { key: "i", inclusive: false },
+    } as const;
+    const senateBounds = {
+      lower: { key: "s", inclusive: true },
+      upper: { key: "t", inclusive: false },
+    } as const;
 
-    for (const bill of bills) {
-      if (bill.billType.startsWith("h")) houseCount++;
-      else senateCount++;
+    const [houseCount, senateCount] = await billsByChamber.countBatch(ctx, [
+      { ...ns, bounds: houseBounds },
+      { ...ns, bounds: senateBounds },
+    ]);
+    const totalCount = houseCount + senateCount;
 
-      const stage = bill.progressStage || 20;
-      const existing = stageMap.get(stage);
-      if (existing) {
-        existing.count++;
-      } else {
-        stageMap.set(stage, {
-          description:
-            bill.progressDescription ||
-            BILL_STAGE_DESCRIPTIONS[stage] ||
-            "Unknown",
-          count: 1,
-        });
+    // Skip the write if aggregates haven't been backfilled yet — otherwise we
+    // would zero out the existing precomputed row.
+    if (totalCount === 0) {
+      const billExists = await ctx.db
+        .query("bills")
+        .withIndex("by_congress", (q) => q.eq("congress", args.congress))
+        .first();
+      if (billExists) {
+        console.warn(
+          `recomputeCongressStats: aggregates report 0 bills for congress ${args.congress} but the table is non-empty. Run aggregateBackfill:run first.`,
+        );
+        return;
       }
     }
 
-    const stageCounts = Array.from(stageMap.entries()).map(([stage, data]) => ({
-      stage,
-      description: data.description,
-      count: data.count,
+    const stageQueries = BILL_STAGES.map(({ stage }) => ({
+      ...ns,
+      bounds: { eq: stage } as const,
     }));
+    const stageResults = await billsByStage.countBatch(ctx, stageQueries);
+
+    const stageCounts = BILL_STAGES.map(({ stage, description }, i) => ({
+      stage,
+      description,
+      count: stageResults[i] ?? 0,
+    })).filter((s) => s.count > 0);
 
     const stats = {
       congress: args.congress,
-      totalCount: bills.length,
+      totalCount,
       houseCount,
       senateCount,
       stageCounts,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bills-in-congress",
       "version": "0.2.0",
       "dependencies": {
+        "@convex-dev/aggregate": "^0.2.1",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-progress": "^1.1.1",
@@ -21,6 +22,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
         "convex": "^1.17.0",
+        "convex-helpers": "^0.1.114",
         "date-fns": "^4.1.0",
         "framer-motion": "^11.18.1",
         "lucide-react": "^0.469.0",
@@ -65,6 +67,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@convex-dev/aggregate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@convex-dev/aggregate/-/aggregate-0.2.1.tgz",
+      "integrity": "sha512-z8GeUC+cIZEgtMXecX6WTBQHNW4E2ioRsc5IkO8BWnCjgDOru/Mw8zXe9JPe35JkqDjlSVKuwxiQHKs/jaYAyA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.24.8"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2668,13 +2679,14 @@
       }
     },
     "node_modules/convex": {
-      "version": "1.31.7",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.31.7.tgz",
-      "integrity": "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
+      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "ws": "8.18.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -2686,6 +2698,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.0.0",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -2695,7 +2708,44 @@
         "@clerk/clerk-react": {
           "optional": true
         },
+        "@clerk/react": {
+          "optional": true
+        },
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convex-helpers": {
+      "version": "0.1.114",
+      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.114.tgz",
+      "integrity": "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "convex-helpers": "bin.cjs"
+      },
+      "peerDependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "convex": "^1.32.0",
+        "hono": "^4.0.5",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "typescript": "^5.5",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }
@@ -5632,7 +5682,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5864,6 +5914,27 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "optimize-images": "tsx scripts/optimize-images.ts"
   },
   "dependencies": {
+    "@convex-dev/aggregate": "^0.2.1",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-progress": "^1.1.1",
@@ -23,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
     "convex": "^1.17.0",
+    "convex-helpers": "^0.1.114",
     "date-fns": "^4.1.0",
     "framer-motion": "^11.18.1",
     "lucide-react": "^0.469.0",


### PR DESCRIPTION
## Summary

The homepage's per-congress totals were silently capped at 10,000 bills (showing as House ~5,418 + Senate ~4,582 — the source of the perceived "5,000 row" cap). The cause was `recomputeCongressStats` scanning the bills table with `.take(10000)` to stay under Convex's per-query document limit.

Verified against prod (`industrious-llama-331`):

| Congress | Real bills in DB | `congressStats.totalCount` (homepage) |
|----------|------------------|----------------------------------------|
| 117      | **17,828**       | 10,000 (capped) — H 5,418 + S 4,582    |
| 118      | **19,314**       | 10,000 (capped) — H 5,493 + S 4,507    |
| 119      | 5,764            | 5,764 (in progress, no cap hit yet)    |

This PR replaces the truncating scan with two `TableAggregate` instances from `@convex-dev/aggregate` and keeps them in sync via `convex-helpers/server/triggers`, so totals are correct regardless of how large any congress grows.

## Changes

- **`convex/convex.config.ts`** (new) — registers two named aggregate components.
- **`convex/aggregates.ts`** (new) — defines `billsByChamber` (namespace = congress, key = `billType`) and `billsByStage` (namespace = congress, key = `progressStage`).
- **`convex/functions.ts`** (new) — wraps `internalMutation` / `mutation` with `customMutation(..., customCtx(triggers.wrapDB))` so every insert/patch/delete on `bills` updates both aggregates atomically.
- **`convex/mutations.ts`** — switched to the trigger-aware mutation builder; rewrote `recomputeCongressStats` to read O(log n) counts from the aggregates (lexicographic bounds `[h, i)` / `[s, t)` for chambers, `{ eq: stage }` for stages). Added a guard that refuses to overwrite a populated `congressStats` row with zeros if the aggregate is somehow empty.
- **`convex/aggregateBackfill.ts`** (new) — self-scheduling paginated backfill via `paginate()` + `insertIfDoesNotExist`, plus a recompute-all step that runs once the backfill completes. Idempotent.

## Deploy steps

1. Merge & deploy (Convex codegen will rewrite `convex/_generated/api.{js,d.ts}` to populate the `components` typing — the temporary version in this PR uses `componentsGeneric()` so local typecheck passes without credentials).
2. Run the one-time backfill against prod:
   ```bash
   npx convex run --prod aggregateBackfill:run '{}'
   ```
   This kicks off batches of 500 bills until the table is fully ingested into both aggregates, then automatically runs `recomputeCongressStats` for every congress.

The recompute guard ensures the homepage keeps showing the old (capped) numbers between deploy and backfill rather than flashing zero.

## Test plan

- [x] `npx tsc -p convex/tsconfig.json` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npx next build` — passes (107 static pages generated)
- [ ] After deploy: run `aggregateBackfill:run '{}'`, then verify on the homepage that congresses 117/118 show ~17,828 / ~19,314 instead of 10,000.
- [ ] After backfill: run a manual incremental sync and confirm new bills increment the aggregates (check via `bills:getAllCongressOverview`).

## Known follow-up (not in scope)

`recomputeCongressPolicyAreas` and `recomputeCongressSponsors` still use `.take(10000)`. Their top-50 *lists* are mostly correct because top entries appear in the early bills, but per-row counts can be slightly low. Worth a follow-up PR using either denormalized rollup tables or additional aggregates keyed by `[congress, sponsorName]` / `[congress, policyAreaName]`.

https://claude.ai/code/session_01YMhWaz9bzNCpcmn3y9VuyB