### PR TITLE
fix: harden aggregate sync against partial backfill states

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -16,11 +16,17 @@ import { billsByChamber, billsByStage } from "./aggregates";
  * Any mutation that uses `internalMutation` / `mutation` from this module
  * (rather than directly from `_generated/server`) will run these triggers
  * transactionally on every insert / patch / replace / delete to `bills`.
+ *
+ * We use `idempotentTrigger()` (which calls `insertIfDoesNotExist` /
+ * `replaceOrInsert` / `deleteIfExists` internally) so that writes survive
+ * temporary out-of-sync states — e.g. a sync running between deploy and the
+ * one-time `aggregateBackfill:run`, or a repair run that touches bills the
+ * backfill hasn't reached yet. It's essentially free to use permanently.
  */
 const triggers = new Triggers<DataModel>();
 
-triggers.register("bills", billsByChamber.trigger());
-triggers.register("bills", billsByStage.trigger());
+triggers.register("bills", billsByChamber.idempotentTrigger());
+triggers.register("bills", billsByStage.idempotentTrigger());
 
 /** Drop-in replacement for `internalMutation` that fires bill triggers. */
 export const internalMutation = customMutation(

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -265,19 +265,21 @@ export const recomputeCongressStats = internalMutation({
     ]);
     const totalCount = houseCount + senateCount;
 
-    // Skip the write if aggregates haven't been backfilled yet — otherwise we
-    // would zero out the existing precomputed row.
-    if (totalCount === 0) {
-      const billExists = await ctx.db
-        .query("bills")
-        .withIndex("by_congress", (q) => q.eq("congress", args.congress))
-        .first();
-      if (billExists) {
-        console.warn(
-          `recomputeCongressStats: aggregates report 0 bills for congress ${args.congress} but the table is non-empty. Run aggregateBackfill:run first.`,
-        );
-        return;
-      }
+    // Guard: if the aggregate reports fewer bills than we can see in a small
+    // probe of the bills table, the aggregate hasn't been fully backfilled
+    // yet. Skip the write so we don't clobber a valid `congressStats` row
+    // with a stale or empty count. Triggers will keep things in sync once
+    // `aggregateBackfill:run` completes.
+    const probe = await ctx.db
+      .query("bills")
+      .withIndex("by_congress", (q) => q.eq("congress", args.congress))
+      .take(100);
+    if (probe.length > totalCount) {
+      console.warn(
+        `recomputeCongressStats: aggregate reports ${totalCount} bills for congress ${args.congress} ` +
+          `but a 100-bill probe returned ${probe.length}. Skipping write — run aggregateBackfill:run to populate aggregates.`,
+      );
+      return;
     }
 
     const stageQueries = BILL_STAGES.map(({ stage }) => ({


### PR DESCRIPTION
Two safety improvements so the deploy/backfill transition can't corrupt homepage stats:

1. Use `idempotentTrigger()` instead of `trigger()` for both bill aggregates. A sync running between deploy and the one-time `aggregateBackfill:run` (or a repair run that patches a bill the backfill hasn't reached) previously risked throwing on `aggregate.insert` of a doc that already exists, or `.delete` of one that doesn't. The idempotent variants use `insertIfDoesNotExist` / `replaceOrInsert` / `deleteIfExists` and are essentially free to use permanently.

2. Tighten the `recomputeCongressStats` guard. The previous version only skipped the write when the aggregate reported exactly 0 bills. That left a window where a partially-backfilled aggregate (say, 50 bills) would overwrite a valid 10,000-row `congressStats` with 50. Replace with a 100-bill probe of the bills table: if the probe returns more bills than the aggregate reports, the aggregate is out of sync — skip the write and log a warning.

Both `npx tsc -p convex/tsconfig.json` and `npx next build` pass.

https://claude.ai/code/session_01YMhWaz9bzNCpcmn3y9VuyB