### PR TITLE
redesign: editorial design language across the entire site

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,78 +1,162 @@
-import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { GithubIcon, BookOpen, Scale, Brain, AlertTriangle } from 'lucide-react';
 import { sharedViewport } from '../shared-metadata';
-import type { Viewport } from 'next';
+import type { Metadata, Viewport } from 'next';
+import { ArrowRight } from 'lucide-react';
 
 export const viewport: Viewport = sharedViewport;
 
+export const metadata: Metadata = {
+  title: 'About',
+  description:
+    'About Bills.Congress — an independent record of legislation in the United States Congress.',
+};
+
 export default function AboutPage() {
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-background">
-      <div className="container py-12">
-        <div className="mx-auto max-w-5xl space-y-12">
-          <div className="space-y-4 text-center">
-            <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl">
-              About Congressional Bill Tracker
-            </h1>
-            <p className="mx-auto max-w-[700px] text-gray-600 dark:text-gray-400 md:text-xl">
-              Empowering citizens with transparent, accessible information about
-              legislative processes and congressional activities.
-            </p>
-          </div>
-
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            {features.map((feature) => (
-              <div
-                key={feature.title}
-                className="flex flex-col items-center space-y-2 rounded-lg border p-6 text-center hover:bg-muted/50"
-              >
-                <feature.icon className="h-8 w-8 text-primary" />
-                <h3 className="font-semibold">{feature.title}</h3>
-                <p className="text-sm text-muted-foreground">{feature.description}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="space-y-4 text-center">
-            <h2 className="text-3xl font-bold">How It Works</h2>
-            <p className="mx-auto max-w-[700px] text-gray-600 dark:text-gray-400">
-              Our platform combines official congressional data with AI-powered
-              analysis to make legislative information more accessible and
-              understandable.
-            </p>
-          </div>
-
-          <div className="flex justify-center">
-            <Link href="/bills">
-              <Button size="lg">Start Exploring Bills</Button>
-            </Link>
-          </div>
+    <article className="animate-fade-in">
+      <header className="border-b border-border">
+        <div className="container-editorial py-12 sm:py-16">
+          <p className="label-eyebrow mb-3">Colophon</p>
+          <h1 className="font-serif text-display-md sm:text-display-lg font-semibold leading-[1.05] tracking-tight max-w-3xl">
+            A clear, independent view of the U.S. Congress.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base sm:text-lg text-muted-foreground leading-relaxed">
+            Bills.Congress is a public-interest project that reorganises the
+            government's own data into a calmer, more readable record of the
+            laws being made on your behalf.
+          </p>
         </div>
-      </div>
-    </div>
+      </header>
+
+      <section className="container-editorial py-14">
+        <div className="grid lg:grid-cols-12 gap-10 lg:gap-16">
+          <div className="lg:col-span-8 space-y-10">
+            <div>
+              <p className="label-eyebrow mb-2">Why this exists</p>
+              <h2 className="font-serif text-display-sm font-semibold tracking-tight mb-3">
+                Government data, made human-readable.
+              </h2>
+              <p className="text-base font-serif leading-relaxed text-foreground">
+                Congress.gov publishes everything you need to follow legislation —
+                but it's optimised for legislative staff, not citizens. Titles
+                are jargon, status codes are cryptic, and you have to know what
+                you're looking for before you can find it. Bills.Congress takes
+                the same primary data and presents it the way a newspaper of
+                record would: clearly indexed, plainly summarised, fast to read.
+              </p>
+            </div>
+
+            <div className="rule" />
+
+            <div>
+              <p className="label-eyebrow mb-2">How it works</p>
+              <h2 className="font-serif text-display-sm font-semibold tracking-tight mb-3">
+                Built on public data, processed transparently.
+              </h2>
+              <ol className="space-y-5 mt-5">
+                {steps.map((step, i) => (
+                  <li key={step.title} className="grid grid-cols-12 gap-4 border-b border-border pb-5 last:border-0">
+                    <span className="col-span-1 font-mono text-sm text-muted-foreground tabular pt-0.5">
+                      0{i + 1}
+                    </span>
+                    <div className="col-span-11">
+                      <p className="font-serif text-lg font-semibold tracking-tight mb-1">
+                        {step.title}
+                      </p>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {step.body}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <div className="rule" />
+
+            <div>
+              <p className="label-eyebrow mb-2">Get involved</p>
+              <h2 className="font-serif text-display-sm font-semibold tracking-tight mb-3">
+                Open source, by design.
+              </h2>
+              <p className="text-base text-muted-foreground leading-relaxed mb-5">
+                Every line of code, every data transformation, and every
+                AI-generated summary prompt is available to inspect. If you find
+                something incorrect or have an idea, please open an issue or
+                pull request on GitHub.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <a
+                  href="https://github.com/shreyashguptas/billsincongress"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-sm border border-border px-4 py-2.5 text-sm font-medium text-foreground hover:bg-secondary"
+                >
+                  Source on GitHub
+                  <ArrowRight className="h-4 w-4" />
+                </a>
+                <Link
+                  href="/bills"
+                  className="inline-flex items-center gap-2 rounded-sm bg-foreground px-4 py-2.5 text-sm font-medium text-background hover:bg-foreground/85"
+                >
+                  Explore the bills
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          {/* Sidebar — facts box */}
+          <aside className="lg:col-span-4">
+            <div className="lg:sticky lg:top-24 border-l border-border pl-6 space-y-6">
+              <div>
+                <p className="label-eyebrow mb-2">At a glance</p>
+                <p className="font-serif text-xl font-semibold tracking-tight leading-tight">
+                  An independent record of every bill in Congress.
+                </p>
+              </div>
+              <dl className="space-y-3 text-sm">
+                {facts.map((f) => (
+                  <div key={f.label} className="border-b border-border pb-2 flex justify-between gap-3">
+                    <dt className="text-muted-foreground">{f.label}</dt>
+                    <dd className="text-foreground font-medium text-right">{f.value}</dd>
+                  </div>
+                ))}
+              </dl>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Bills.Congress is not affiliated with the United States
+                government. Source data is in the public domain.
+              </p>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </article>
   );
 }
 
-const features = [
+const steps = [
   {
-    title: 'Open Source',
-    description: 'Transparent and community-driven development for accountability.',
-    icon: GithubIcon,
+    title: 'Direct ingestion from Congress.gov',
+    body: 'We pull bill text, sponsor data, and status changes from the official Congress.gov API. No scraping, no intermediaries.',
   },
   {
-    title: 'Legislative Tracking',
-    description: 'Real-time updates on bill status and congressional activities.',
-    icon: BookOpen,
+    title: 'Continuous synchronisation',
+    body: 'A scheduled job keeps our database in step with the public record. Every bill page shows when its data was last refreshed.',
   },
   {
-    title: 'AI Analysis',
-    description: 'Advanced AI summaries and insights for better understanding.',
-    icon: Brain,
+    title: 'Plain-English summaries',
+    body: 'Long-form bill text is condensed into clear summaries by an AI model — never replacing the original, only making it easier to enter.',
   },
   {
-    title: 'Unofficial Resource',
-    description: 'Independent platform using official Congress.gov API data. Not affiliated with the U.S. government.',
-    icon: AlertTriangle,
+    title: 'Open data, open code',
+    body: 'The source code, schema, and pipeline are all on GitHub. You can host your own copy or contribute back changes.',
   },
+];
+
+const facts = [
+  { label: 'Data source', value: 'Congress.gov API' },
+  { label: 'Update cadence', value: 'Daily' },
+  { label: 'Coverage', value: 'Recent Congresses' },
+  { label: 'License', value: 'Open source' },
 ];

--- a/app/bills/[id]/page.tsx
+++ b/app/bills/[id]/page.tsx
@@ -57,7 +57,17 @@ export default async function BillPage({ params }: PageProps): Promise<ReactElem
     }
 
     return (
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense
+        fallback={
+          <div className="container-editorial py-16">
+            <div className="space-y-3">
+              <div className="h-3 w-24 bg-secondary rounded-sm animate-pulse" />
+              <div className="h-10 w-2/3 bg-secondary rounded-sm animate-pulse" />
+              <div className="h-4 w-1/2 bg-secondary rounded-sm animate-pulse" />
+            </div>
+          </div>
+        }
+      >
         <BillDetails bill={bill} />
       </Suspense>
     );

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -1,29 +1,16 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { Suspense, useState } from 'react';
-import { useEffect } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import { billsService } from '@/lib/services/bills-service';
 import type { Bill } from '../../lib/types/bill';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
-import { Filter } from 'lucide-react';
+import { SlidersHorizontal } from 'lucide-react';
 
-// Dynamic imports with no SSR
-const BillsFilter = dynamic(
-  () => import('@/components/bills/bills-filter'),
-  { ssr: false }
-);
-
-const BillCard = dynamic(
-  () => import('@/components/bills/bill-card'),
-  { ssr: false }
-);
-
-const SyncStatus = dynamic(
-  () => import('@/components/bills/sync-status'),
-  { ssr: false }
-);
+const BillsFilter = dynamic(() => import('@/components/bills/bills-filter'), { ssr: false });
+const BillCard = dynamic(() => import('@/components/bills/bill-card'), { ssr: false });
+const SyncStatus = dynamic(() => import('@/components/bills/sync-status'), { ssr: false });
 
 const ITEMS_PER_PAGE = 9;
 
@@ -31,7 +18,7 @@ export default function BillsPage() {
   const [bills, setBills] = useState<Bill[]>([]);
   const [totalBills, setTotalBills] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState<string>(() => 
+  const [statusFilter, setStatusFilter] = useState<string>(() =>
     typeof window !== 'undefined' ? localStorage.getItem('billsStatusFilter') || 'all' : 'all'
   );
   const [introducedDateFilter, setIntroducedDateFilter] = useState<string>(() =>
@@ -76,28 +63,19 @@ export default function BillsPage() {
     billNumber: '',
     title: '',
     sponsor: '',
-    congress: 'all'
+    congress: 'all',
   });
   const [hasFilterChanges, setHasFilterChanges] = useState(false);
 
-  // Results statistics for UI display
-  const [filteredStats, setFilteredStats] = useState({
-    totalBills: 0,         // Total bills in database 
-    filteredCount: 0,       // Count after filters applied
-    displayedCount: 0       // Currently displayed count
-  });
-
-  // Fetch Congress info on mount
   useEffect(() => {
     const fetchCongressInfo = async () => {
       try {
         const info = await billsService.getCongressInfo();
         setCongressInfo(info);
-      } catch (error) {
-        console.error('Error fetching Congress info:', error);
+      } catch (e) {
+        console.error('Error fetching Congress info:', e);
       }
     };
-
     fetchCongressInfo();
   }, []);
 
@@ -115,19 +93,11 @@ export default function BillsPage() {
       localStorage.setItem('billsCongressFilter', congressFilter);
     }
   }, [
-    statusFilter,
-    introducedDateFilter,
-    lastActionDateFilter,
-    sponsorFilter,
-    titleFilter,
-    stateFilter,
-    policyAreaFilter,
-    billTypeFilter,
-    billNumberFilter,
-    congressFilter
+    statusFilter, introducedDateFilter, lastActionDateFilter, sponsorFilter,
+    titleFilter, stateFilter, policyAreaFilter, billTypeFilter,
+    billNumberFilter, congressFilter,
   ]);
 
-  // Initialize pendingFilters with current filter values
   useEffect(() => {
     setPendingFilters({
       status: statusFilter,
@@ -139,35 +109,16 @@ export default function BillsPage() {
       billNumber: billNumberFilter,
       title: titleFilter,
       sponsor: sponsorFilter,
-      congress: congressFilter
+      congress: congressFilter,
     });
   }, [
-    statusFilter,
-    introducedDateFilter,
-    lastActionDateFilter,
-    stateFilter,
-    policyAreaFilter,
-    billTypeFilter,
-    billNumberFilter,
-    titleFilter,
-    sponsorFilter,
-    congressFilter
+    statusFilter, introducedDateFilter, lastActionDateFilter, stateFilter,
+    policyAreaFilter, billTypeFilter, billNumberFilter, titleFilter,
+    sponsorFilter, congressFilter,
   ]);
 
-  // Update the statistics whenever the relevant state changes
-  useEffect(() => {
-    setFilteredStats({
-      totalBills: totalBills,
-      filteredCount: totalBills,
-      displayedCount: bills.length
-    });
-  }, [bills.length, totalBills]);
-
   const handleClearAllFilters = () => {
-    // Reset pagination when clearing filters
     setCurrentPage(1);
-    
-    // Reset both actual and pending filters
     setStatusFilter('all');
     setIntroducedDateFilter('all');
     setLastActionDateFilter('all');
@@ -178,23 +129,15 @@ export default function BillsPage() {
     setBillTypeFilter('all');
     setBillNumberFilter('');
     setCongressFilter('all');
-    setPendingFilters(prev => ({
-      ...prev,
-      billNumber: ''
-    }));
+    setPendingFilters((p) => ({ ...p, billNumber: '' }));
     setHasFilterChanges(false);
 
     if (typeof window !== 'undefined') {
-      localStorage.removeItem('billsStatusFilter');
-      localStorage.removeItem('billsIntroducedDateFilter');
-      localStorage.removeItem('billsLastActionDateFilter');
-      localStorage.removeItem('billsSponsorFilter');
-      localStorage.removeItem('billsTitleFilter');
-      localStorage.removeItem('billsStateFilter');
-      localStorage.removeItem('billsPolicyAreaFilter');
-      localStorage.removeItem('billsTypeFilter');
-      localStorage.removeItem('billsNumberFilter');
-      localStorage.removeItem('billsCongressFilter');
+      [
+        'billsStatusFilter','billsIntroducedDateFilter','billsLastActionDateFilter',
+        'billsSponsorFilter','billsTitleFilter','billsStateFilter',
+        'billsPolicyAreaFilter','billsTypeFilter','billsNumberFilter','billsCongressFilter',
+      ].forEach((k) => localStorage.removeItem(k));
     }
   };
 
@@ -207,45 +150,23 @@ export default function BillsPage() {
         page: nextPage,
         itemsPerPage: ITEMS_PER_PAGE,
         status: statusFilter,
-        introducedDateFilter: introducedDateFilter,
-        lastActionDateFilter: lastActionDateFilter,
-        sponsorFilter: sponsorFilter,
-        titleFilter: titleFilter,
-        stateFilter: stateFilter,
+        introducedDateFilter,
+        lastActionDateFilter,
+        sponsorFilter,
+        titleFilter,
+        stateFilter,
         policyArea: policyAreaFilter,
         billType: billTypeFilter,
         billNumber: billNumberFilter,
         congress: congressFilter,
       });
-      
-      // Create a Map of existing bill IDs for efficient lookup
-      const existingBillIds = new Set(bills.map(bill => bill.id));
-      
-      // Filter out any duplicate bills that might be returned
-      const newBills = response.data.filter(bill => !existingBillIds.has(bill.id));
-      
-      // Only add new, unique bills to the list
-      setBills(prevBills => [...prevBills, ...newBills]);
-      
-      // Update total count to match the filtered count returned from the server
+      const existing = new Set(bills.map((b) => b.id));
+      const newBills = response.data.filter((b) => !existing.has(b.id));
+      setBills((prev) => [...prev, ...newBills]);
       setTotalBills(response.count);
-      
-      // Update current page
       setCurrentPage(nextPage);
-      
-      // Update filtered stats
-      setFilteredStats(prev => ({
-        ...prev,
-        filteredCount: response.count,
-        displayedCount: prev.displayedCount + newBills.length
-      }));
-      
-      // Log for debugging
-      console.log(`Loaded ${newBills.length} new bills. Total: ${bills.length + newBills.length}/${response.count}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to load more bills';
-      console.error('Error loading more bills:', error);
-      setError(message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load more bills');
     } finally {
       setIsLoadingMore(false);
     }
@@ -260,54 +181,36 @@ export default function BillsPage() {
           page: 1,
           itemsPerPage: ITEMS_PER_PAGE,
           status: statusFilter,
-          introducedDateFilter: introducedDateFilter,
-          lastActionDateFilter: lastActionDateFilter,
-          sponsorFilter: sponsorFilter,
-          titleFilter: titleFilter,
-          stateFilter: stateFilter,
+          introducedDateFilter,
+          lastActionDateFilter,
+          sponsorFilter,
+          titleFilter,
+          stateFilter,
           policyArea: policyAreaFilter,
           billType: billTypeFilter,
           billNumber: billNumberFilter,
           congress: congressFilter,
         });
-        
-        // Update state with the fetched data
         setBills(response.data);
         setTotalBills(response.count);
         setCurrentPage(1);
-        
-        // Log for debugging
-        console.log(`Initial fetch: ${response.data.length} bills found out of ${response.count} total.`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Failed to fetch bills';
-        console.error('Error fetching bills:', error);
-        setError(message);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to fetch bills');
       } finally {
         setIsLoading(false);
       }
     };
-
     fetchBills();
   }, [
-    statusFilter,
-    introducedDateFilter,
-    lastActionDateFilter,
-    sponsorFilter,
-    titleFilter,
-    stateFilter,
-    policyAreaFilter,
-    billTypeFilter,
-    billNumberFilter,
-    congressFilter
+    statusFilter, introducedDateFilter, lastActionDateFilter, sponsorFilter,
+    titleFilter, stateFilter, policyAreaFilter, billTypeFilter,
+    billNumberFilter, congressFilter,
   ]);
 
-  // Only show "Load More" button if there are more bills to load
   const hasMoreBills = totalBills > bills.length;
 
   const handleApplyFilters = () => {
-    // Reset pagination when applying new filters
     setCurrentPage(1);
-    
     setStatusFilter(pendingFilters.status);
     setIntroducedDateFilter(pendingFilters.introducedDate);
     setLastActionDateFilter(pendingFilters.lastActionDate);
@@ -323,54 +226,62 @@ export default function BillsPage() {
   };
 
   const handlePendingFilterChange = (filterType: string, value: string) => {
-    setPendingFilters(prev => ({ ...prev, [filterType]: value }));
+    setPendingFilters((prev) => ({ ...prev, [filterType]: value }));
     setHasFilterChanges(true);
   };
 
+  const filtersActive = hasFiltersActive(
+    statusFilter, introducedDateFilter, lastActionDateFilter,
+    sponsorFilter, titleFilter, stateFilter, policyAreaFilter,
+    billTypeFilter, billNumberFilter, congressFilter,
+  );
+
   return (
-    <main className="container mx-auto px-4 py-8">
-      <div className="flex items-baseline justify-between mb-8">
-        <div>
-          <h1 className="text-3xl font-bold mb-1">All Bills</h1>
-          <p className="text-sm text-muted-foreground">
-            Browse bills introduced in Congress
-            {congressInfo && (
-              <span className="ml-1">
-                ({congressInfo.startYear}–{congressInfo.endYear})
-              </span>
-            )}
-          </p>
-          <SyncStatus />
-        </div>
-        <div className="text-sm text-muted-foreground">
-          {bills.length > 0 ? (
-            <>
-              Showing {bills.length} out of {totalBills} bills
-              {hasFiltersActive() && (
-                <span className="ml-1">(filtered)</span>
+    <div className="animate-fade-in">
+      {/* Page header — editorial */}
+      <section className="border-b border-border">
+        <div className="container-editorial py-10 sm:py-12">
+          <p className="label-eyebrow mb-3">The record</p>
+          <h1 className="font-serif text-display-md sm:text-display-lg font-semibold leading-[1.05] tracking-tight">
+            All bills
+          </h1>
+          <div className="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            <span>
+              Browse legislation introduced in Congress
+              {congressInfo && (
+                <>
+                  {' '}
+                  <span className="font-mono tabular">
+                    ({congressInfo.startYear}–{congressInfo.endYear})
+                  </span>
+                </>
               )}
-            </>
-          ) : isLoading ? (
-            <>Loading bills...</>
-          ) : (
-            <>No bills found</>
-          )}
+              .
+            </span>
+            <SyncStatus />
+          </div>
         </div>
-      </div>
-      
-      <div className="flex flex-col lg:flex-row gap-8">
-        {/* Mobile Filter Button */}
-        <div className="lg:hidden mb-4">
+      </section>
+
+      <div className="container-editorial py-8 lg:py-10">
+        {/* Mobile filter trigger */}
+        <div className="lg:hidden mb-5">
           <Sheet open={isFilterSheetOpen} onOpenChange={setIsFilterSheetOpen}>
             <SheetTrigger asChild>
-              <Button variant="outline" className="w-full flex items-center gap-2">
-                <Filter className="h-4 w-4" />
+              <Button variant="outline" className="w-full">
+                <SlidersHorizontal className="h-4 w-4" />
                 Filters
+                {filtersActive && (
+                  <span className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-accent" />
+                )}
               </Button>
             </SheetTrigger>
-            <SheetContent side="bottom" className="h-[80vh]">
-              <div className="h-full flex flex-col">
-                <div className="flex-1 overflow-y-auto">
+            <SheetContent side="bottom" className="h-[85vh] border-t border-border bg-background p-0">
+              <div className="flex h-full flex-col">
+                <div className="border-b border-border px-5 py-4">
+                  <p className="font-serif text-lg font-semibold tracking-tight">Filter bills</p>
+                </div>
+                <div className="flex-1 overflow-y-auto px-5 py-5">
                   <BillsFilter
                     statusFilter={pendingFilters.status}
                     introducedDateFilter={pendingFilters.introducedDate}
@@ -382,27 +293,23 @@ export default function BillsPage() {
                     billTypeFilter={pendingFilters.billType}
                     billNumberFilter={pendingFilters.billNumber}
                     congressFilter={pendingFilters.congress}
-                    onStatusChange={(value) => handlePendingFilterChange('status', value)}
-                    onIntroducedDateChange={(value) => handlePendingFilterChange('introducedDate', value)}
-                    onLastActionDateChange={(value) => handlePendingFilterChange('lastActionDate', value)}
-                    onSponsorChange={(value) => handlePendingFilterChange('sponsor', value)}
-                    onTitleChange={(value) => handlePendingFilterChange('title', value)}
-                    onStateChange={(value) => handlePendingFilterChange('state', value)}
-                    onPolicyAreaChange={(value) => handlePendingFilterChange('policyArea', value)}
-                    onBillTypeChange={(value) => handlePendingFilterChange('billType', value)}
-                    onBillNumberChange={(value) => handlePendingFilterChange('billNumber', value)}
-                    onCongressChange={(value) => handlePendingFilterChange('congress', value)}
+                    onStatusChange={(v) => handlePendingFilterChange('status', v)}
+                    onIntroducedDateChange={(v) => handlePendingFilterChange('introducedDate', v)}
+                    onLastActionDateChange={(v) => handlePendingFilterChange('lastActionDate', v)}
+                    onSponsorChange={(v) => handlePendingFilterChange('sponsor', v)}
+                    onTitleChange={(v) => handlePendingFilterChange('title', v)}
+                    onStateChange={(v) => handlePendingFilterChange('state', v)}
+                    onPolicyAreaChange={(v) => handlePendingFilterChange('policyArea', v)}
+                    onBillTypeChange={(v) => handlePendingFilterChange('billType', v)}
+                    onBillNumberChange={(v) => handlePendingFilterChange('billNumber', v)}
+                    onCongressChange={(v) => handlePendingFilterChange('congress', v)}
                     onClearAllFilters={handleClearAllFilters}
                     isMobile={true}
                   />
                 </div>
-                <div className="py-4 border-t">
-                  <Button 
-                    className="w-full" 
-                    onClick={handleApplyFilters}
-                    disabled={!hasFilterChanges}
-                  >
-                    Apply Filters
+                <div className="border-t border-border px-5 py-4">
+                  <Button className="w-full" onClick={handleApplyFilters} disabled={!hasFilterChanges}>
+                    Apply filters
                   </Button>
                 </div>
               </div>
@@ -410,97 +317,128 @@ export default function BillsPage() {
           </Sheet>
         </div>
 
-        {/* Desktop Sidebar Filters */}
-        <aside className="hidden lg:block lg:w-[300px] shrink-0">
-          <div className="space-y-6">
-            <BillsFilter
-              statusFilter={pendingFilters.status}
-              introducedDateFilter={pendingFilters.introducedDate}
-              lastActionDateFilter={pendingFilters.lastActionDate}
-              sponsorFilter={pendingFilters.sponsor}
-              titleFilter={pendingFilters.title}
-              stateFilter={pendingFilters.state}
-              policyAreaFilter={pendingFilters.policyArea}
-              billTypeFilter={pendingFilters.billType}
-              billNumberFilter={pendingFilters.billNumber}
-              congressFilter={pendingFilters.congress}
-              onStatusChange={(value) => handlePendingFilterChange('status', value)}
-              onIntroducedDateChange={(value) => handlePendingFilterChange('introducedDate', value)}
-              onLastActionDateChange={(value) => handlePendingFilterChange('lastActionDate', value)}
-              onSponsorChange={(value) => handlePendingFilterChange('sponsor', value)}
-              onTitleChange={(value) => handlePendingFilterChange('title', value)}
-              onStateChange={(value) => handlePendingFilterChange('state', value)}
-              onPolicyAreaChange={(value) => handlePendingFilterChange('policyArea', value)}
-              onBillTypeChange={(value) => handlePendingFilterChange('billType', value)}
-              onBillNumberChange={(value) => handlePendingFilterChange('billNumber', value)}
-              onCongressChange={(value) => handlePendingFilterChange('congress', value)}
-              onClearAllFilters={handleClearAllFilters}
-              isMobile={false}
-            />
-            <Button 
-              className="w-full" 
-              onClick={handleApplyFilters}
-              disabled={!hasFilterChanges}
-            >
-              Apply Filters
-            </Button>
-          </div>
-        </aside>
-
-        {/* Main Content */}
-        <div className="flex-1">
-          {error && (
-            <div className="text-red-500 mb-6">
-              {error}
+        <div className="flex flex-col lg:flex-row gap-10 lg:gap-12">
+          {/* Desktop sidebar */}
+          <aside className="hidden lg:block lg:w-[260px] shrink-0">
+            <div className="sticky top-24 space-y-6">
+              <BillsFilter
+                statusFilter={pendingFilters.status}
+                introducedDateFilter={pendingFilters.introducedDate}
+                lastActionDateFilter={pendingFilters.lastActionDate}
+                sponsorFilter={pendingFilters.sponsor}
+                titleFilter={pendingFilters.title}
+                stateFilter={pendingFilters.state}
+                policyAreaFilter={pendingFilters.policyArea}
+                billTypeFilter={pendingFilters.billType}
+                billNumberFilter={pendingFilters.billNumber}
+                congressFilter={pendingFilters.congress}
+                onStatusChange={(v) => handlePendingFilterChange('status', v)}
+                onIntroducedDateChange={(v) => handlePendingFilterChange('introducedDate', v)}
+                onLastActionDateChange={(v) => handlePendingFilterChange('lastActionDate', v)}
+                onSponsorChange={(v) => handlePendingFilterChange('sponsor', v)}
+                onTitleChange={(v) => handlePendingFilterChange('title', v)}
+                onStateChange={(v) => handlePendingFilterChange('state', v)}
+                onPolicyAreaChange={(v) => handlePendingFilterChange('policyArea', v)}
+                onBillTypeChange={(v) => handlePendingFilterChange('billType', v)}
+                onBillNumberChange={(v) => handlePendingFilterChange('billNumber', v)}
+                onCongressChange={(v) => handlePendingFilterChange('congress', v)}
+                onClearAllFilters={handleClearAllFilters}
+                isMobile={false}
+              />
+              <Button className="w-full" onClick={handleApplyFilters} disabled={!hasFilterChanges}>
+                Apply filters
+              </Button>
             </div>
-          )}
+          </aside>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-            {isLoading ? (
-              <div className="col-span-full text-center py-8">Loading bills...</div>
-            ) : bills.length > 0 ? (
-              bills.map((bill) => (
-                <Suspense key={bill.id} fallback={<div>Loading bill...</div>}>
-                  <BillCard bill={bill} />
-                </Suspense>
-              ))
-            ) : (
-              <div className="col-span-full text-center py-8">
-                No bills found matching your filters.
+          {/* Results column */}
+          <div className="flex-1 min-w-0">
+            <div className="mb-5 flex items-baseline justify-between gap-3 border-b border-border pb-3">
+              <p className="text-sm text-muted-foreground">
+                {bills.length > 0 ? (
+                  <>
+                    Showing{' '}
+                    <span className="font-mono font-medium text-foreground tabular">
+                      {bills.length}
+                    </span>{' '}
+                    of{' '}
+                    <span className="font-mono font-medium text-foreground tabular">
+                      {totalBills.toLocaleString()}
+                    </span>{' '}
+                    bills
+                    {filtersActive && <span className="ml-1">· filtered</span>}
+                  </>
+                ) : isLoading ? (
+                  'Loading…'
+                ) : (
+                  'No matching bills'
+                )}
+              </p>
+            </div>
+
+            {error && (
+              <div className="mb-6 border border-destructive/30 bg-destructive/5 text-destructive px-4 py-3 text-sm rounded-sm">
+                {error}
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+              {isLoading ? (
+                Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="h-64 border border-border bg-card rounded-sm animate-pulse" />
+                ))
+              ) : bills.length > 0 ? (
+                bills.map((bill) => (
+                  <Suspense key={bill.id} fallback={<div className="h-64 border border-border rounded-sm bg-card" />}>
+                    <BillCard bill={bill} />
+                  </Suspense>
+                ))
+              ) : (
+                <div className="col-span-full border border-dashed border-border rounded-sm p-12 text-center">
+                  <p className="font-serif text-xl tracking-tight mb-2">No bills found</p>
+                  <p className="text-sm text-muted-foreground">
+                    Try removing some filters to broaden the search.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {hasMoreBills && (
+              <div className="mt-10 text-center">
+                <Button onClick={handleLoadMore} disabled={isLoadingMore} variant="outline" size="lg">
+                  {isLoadingMore ? 'Loading…' : 'Load more bills'}
+                </Button>
               </div>
             )}
           </div>
-
-          {hasMoreBills && (
-            <div className="mt-8 text-center">
-              <Button
-                onClick={handleLoadMore}
-                disabled={isLoadingMore}
-                variant="outline"
-                className="px-6 py-2"
-              >
-                {isLoadingMore ? 'Loading...' : 'Load More'}
-              </Button>
-            </div>
-          )}
         </div>
       </div>
-    </main>
+    </div>
   );
+}
 
-  // Helper to check if any filters are active
-  function hasFiltersActive() {
-    return (
-      statusFilter !== 'all' ||
-      introducedDateFilter !== 'all' ||
-      lastActionDateFilter !== 'all' ||
-      sponsorFilter !== '' ||
-      titleFilter !== '' ||
-      stateFilter !== 'all' ||
-      policyAreaFilter !== 'all' ||
-      billTypeFilter !== 'all' ||
-      billNumberFilter !== '' ||
-      congressFilter !== 'all'
-    );
-  }
+function hasFiltersActive(
+  statusFilter: string,
+  introducedDateFilter: string,
+  lastActionDateFilter: string,
+  sponsorFilter: string,
+  titleFilter: string,
+  stateFilter: string,
+  policyAreaFilter: string,
+  billTypeFilter: string,
+  billNumberFilter: string,
+  congressFilter: string,
+) {
+  return (
+    statusFilter !== 'all' ||
+    introducedDateFilter !== 'all' ||
+    lastActionDateFilter !== 'all' ||
+    sponsorFilter !== '' ||
+    titleFilter !== '' ||
+    stateFilter !== 'all' ||
+    policyAreaFilter !== 'all' ||
+    billTypeFilter !== 'all' ||
+    billNumberFilter !== '' ||
+    congressFilter !== 'all'
+  );
 }

--- a/app/components/dashboard/DashboardClient.tsx
+++ b/app/components/dashboard/DashboardClient.tsx
@@ -5,6 +5,9 @@ import { useQuery } from 'convex/react';
 import { api } from '../../../convex/_generated/api';
 import { useRouter } from 'next/navigation';
 import { useConvexEnabled } from '../../ConvexClientProvider';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface DashboardProps {
   initialCongress?: number;
@@ -12,27 +15,28 @@ interface DashboardProps {
 
 export default function Dashboard({ initialCongress = 119 }: DashboardProps) {
   const convexEnabled = useConvexEnabled();
-
   if (!convexEnabled) {
     return <ConvexNotConfigured />;
   }
-
   return <DashboardInner initialCongress={initialCongress} />;
 }
 
 function ConvexNotConfigured() {
   return (
-    <div className="min-h-screen bg-congress-navy-950 text-white flex items-center justify-center">
-      <div className="max-w-md text-center p-8">
-        <h2 className="text-2xl font-bold mb-4">Convex Not Configured</h2>
-        <p className="text-congress-navy-300 mb-4">
-          The real-time dashboard requires a Convex backend. Set the{' '}
-          <code className="bg-congress-navy-800 px-1.5 py-0.5 rounded text-sm">
+    <div className="container-editorial py-24">
+      <div className="max-w-md">
+        <p className="label-eyebrow mb-3">Configuration required</p>
+        <h2 className="font-serif text-3xl font-semibold mb-3 tracking-tight">
+          Backend not connected
+        </h2>
+        <p className="text-muted-foreground leading-relaxed mb-2">
+          The live dashboard requires a Convex backend. Set the{' '}
+          <code className="rounded-sm bg-secondary px-1.5 py-0.5 font-mono text-[12px]">
             NEXT_PUBLIC_CONVEX_URL
           </code>{' '}
           environment variable and restart the dev server.
         </p>
-        <p className="text-congress-navy-400 text-sm">
+        <p className="text-sm text-muted-foreground">
           See the project README for setup instructions.
         </p>
       </div>
@@ -45,19 +49,17 @@ function DashboardInner({ initialCongress = 119 }: DashboardProps) {
   const [selectedCongress, setSelectedCongress] = useState(initialCongress);
 
   const allCongressData = useQuery(api.bills.getAllCongressOverview);
-  const congressDashboard = useQuery(api.bills.getCongressDashboard, { congress: selectedCongress });
+  const congressDashboard = useQuery(api.bills.getCongressDashboard, {
+    congress: selectedCongress,
+  });
 
-  const congressNumbers = allCongressData?.map(d => d.congress) || [];
-  
+  const congressNumbers = allCongressData?.map((d) => d.congress) || [];
+
   useEffect(() => {
     if (congressNumbers.length > 0 && !congressNumbers.includes(selectedCongress)) {
       setSelectedCongress(congressNumbers[congressNumbers.length - 1]);
     }
   }, [congressNumbers, selectedCongress]);
-
-  const handleCongressChange = (congress: number) => {
-    setSelectedCongress(congress);
-  };
 
   const handleDrillDown = (filterType: string, filterValue: string | number) => {
     const params = new URLSearchParams();
@@ -72,143 +74,195 @@ function DashboardInner({ initialCongress = 119 }: DashboardProps) {
 
   if (!allCongressData || allCongressData.length === 0) {
     return (
-      <div className="min-h-screen bg-congress-navy-950 text-white flex items-center justify-center">
-        <p className="text-congress-navy-400">No data available</p>
+      <div className="container-editorial py-24 text-center text-muted-foreground">
+        No data available.
       </div>
     );
   }
 
-  const currentStats = allCongressData.find(d => d.congress === selectedCongress);
+  const currentStats = allCongressData.find((d) => d.congress === selectedCongress);
+  const currentTerm = getCongressTermYears(selectedCongress);
 
   return (
-    <div className="min-h-screen bg-congress-navy-950 text-white">
-      {/* Header */}
-      <header className="border-b border-congress-navy-700 bg-congress-navy-900/80 backdrop-blur-sm sticky top-0 z-50">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div>
-              <h1 className="font-display text-2xl md:text-3xl font-bold text-white tracking-tight">
-                Congressional Intelligence
-              </h1>
-              <p className="text-congress-navy-300 text-sm mt-1">
-                Real-time analytics from the People's Chamber
+    <div className="animate-fade-in">
+      {/* ── HERO / Editorial masthead ─────────────────────────────── */}
+      <section className="border-b border-border">
+        <div className="container-editorial py-10 sm:py-14">
+          <div className="flex flex-wrap items-end justify-between gap-6">
+            <div className="max-w-3xl">
+              <p className="label-eyebrow mb-3">
+                The {selectedCongress}
+                {getOrdinalSuffix(selectedCongress)} Congress
+                {currentTerm && (
+                  <span className="ml-2 text-muted-foreground/80 normal-case tracking-normal">
+                    · {currentTerm}
+                  </span>
+                )}
               </p>
-            </div>
-            
-            {/* Congress Selector */}
-            <div className="flex items-center gap-2 overflow-x-auto pb-2 md:pb-0">
-              <span className="text-congress-navy-400 text-sm font-medium shrink-0">Congress:</span>
-              {congressNumbers.sort((a, b) => b - a).map((congress) => (
-                <button
-                  key={congress}
-                  onClick={() => handleCongressChange(congress)}
-                  className={`px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 ${
-                    selectedCongress === congress
-                      ? 'bg-congress-gold-500 text-congress-navy-900 shadow-lg shadow-congress-gold-500/20'
-                      : 'bg-congress-navy-800 text-congress-navy-200 hover:bg-congress-navy-700 hover:text-white'
-                  }`}
+              <h1 className="font-serif text-display-md sm:text-display-lg lg:text-display-xl font-semibold leading-[1.05] tracking-tight">
+                Every bill, every step,
+                <br className="hidden sm:inline" /> in plain view.
+              </h1>
+              <p className="mt-5 text-base sm:text-lg text-muted-foreground max-w-2xl leading-relaxed">
+                A continuous record of legislation moving through the United
+                States Congress — sourced live from Congress.gov, made readable
+                for citizens, journalists and researchers.
+              </p>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Link
+                  href="/bills"
+                  className="inline-flex items-center gap-2 rounded-sm bg-foreground px-4 py-2.5 text-sm font-medium text-background hover:bg-foreground/85 transition-colors"
                 >
-                  {congress}{getOrdinalSuffix(congress)}
-                </button>
-              ))}
+                  Browse all bills
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="/learn"
+                  className="inline-flex items-center gap-2 rounded-sm border border-border px-4 py-2.5 text-sm font-medium text-foreground hover:bg-secondary transition-colors"
+                >
+                  How a bill becomes law
+                </Link>
+              </div>
+            </div>
+
+            {/* Congress selector — quiet sidebar */}
+            <div className="min-w-[180px]">
+              <p className="label-eyebrow mb-2">Congress</p>
+              <div className="flex flex-wrap gap-1">
+                {congressNumbers
+                  .sort((a, b) => b - a)
+                  .map((c) => (
+                    <button
+                      key={c}
+                      onClick={() => setSelectedCongress(c)}
+                      className={cn(
+                        'rounded-sm border px-2.5 py-1 font-mono text-xs transition-colors tabular',
+                        selectedCongress === c
+                          ? 'border-foreground bg-foreground text-background'
+                          : 'border-border text-muted-foreground hover:text-foreground hover:border-foreground/40'
+                      )}
+                    >
+                      {c}
+                      {getOrdinalSuffix(c)}
+                    </button>
+                  ))}
+              </div>
             </div>
           </div>
         </div>
-      </header>
+      </section>
 
-      <main className="container mx-auto px-4 py-8">
-        {/* Stats Overview */}
-        <section className="mb-8">
-          <StatsOverview 
+      {/* ── KEY METRICS row ───────────────────────────────────────── */}
+      <section className="border-b border-border">
+        <div className="container-editorial py-8">
+          <StatsOverview
             stats={currentStats}
             dashboardData={congressDashboard}
             onDrillDown={handleDrillDown}
           />
-        </section>
+        </div>
+      </section>
 
-        {/* Main Charts Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-          {/* Status Donut Chart */}
-          <div className="bg-congress-navy-800/50 rounded-xl border border-congress-navy-700 p-6 backdrop-blur-sm">
-            <h2 className="font-display text-xl font-semibold mb-4 flex items-center gap-2">
-              <span className="w-1 h-6 bg-congress-gold-500 rounded-full"></span>
-              Bill Status Distribution
-            </h2>
+      {/* ── Status distribution + Policy areas ────────────────────── */}
+      <section className="border-b border-border">
+        <div className="container-editorial py-12 grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-14">
+          <div className="lg:col-span-7">
+            <SectionHeader
+              eyebrow="Where bills stand"
+              title="Status distribution"
+              description="Most introduced bills never leave committee. The bar shows how this Congress's introduced bills are distributed across the legislative pipeline."
+            />
             {congressDashboard && (
-              <StatusChart 
-                data={congressDashboard.statusBreakdown} 
+              <StatusBar
+                data={congressDashboard.statusBreakdown}
                 totalBills={congressDashboard.totalBills}
                 onSegmentClick={handleDrillDown}
               />
             )}
           </div>
-
-          {/* Policy Areas */}
-          <div className="bg-congress-navy-800/50 rounded-xl border border-congress-navy-700 p-6 backdrop-blur-sm">
-            <h2 className="font-display text-xl font-semibold mb-4 flex items-center gap-2">
-              <span className="w-1 h-6 bg-congress-crimson-500 rounded-full"></span>
-              Top Policy Areas
-            </h2>
+          <div className="lg:col-span-5">
+            <SectionHeader
+              eyebrow="By subject"
+              title="Top policy areas"
+              description="The most common policy areas tagged on bills introduced this Congress."
+            />
             {congressDashboard && (
-              <PolicyAreaChart 
+              <PolicyAreaList
                 data={congressDashboard.topPolicyAreas}
-                onBarClick={(area) => handleDrillDown('policyArea', area)}
+                onItemClick={(area) => handleDrillDown('policyArea', area)}
               />
             )}
           </div>
         </div>
+      </section>
 
-        {/* Secondary Charts Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-          {/* Timeline Metrics */}
-          <div className="bg-congress-navy-800/50 rounded-xl border border-congress-navy-700 p-6 backdrop-blur-sm">
-            <h2 className="font-display text-xl font-semibold mb-4 flex items-center gap-2">
-              <span className="w-1 h-6 bg-blue-400 rounded-full"></span>
-              Average Days to Progress
-            </h2>
-            {congressDashboard && (
-              <TimelineChart data={congressDashboard.timelineMetrics} />
-            )}
-          </div>
-
-          {/* Top Sponsors */}
-          <div className="bg-congress-navy-800/50 rounded-xl border border-congress-navy-700 p-6 backdrop-blur-sm">
-            <h2 className="font-display text-xl font-semibold mb-4 flex items-center gap-2">
-              <span className="w-1 h-6 bg-emerald-400 rounded-full"></span>
-              Top Sponsors
-            </h2>
-            {congressDashboard && (
-              <SponsorLeaderboard 
-                data={congressDashboard.topSponsors}
-                onSponsorClick={(name) => handleDrillDown('sponsor', name)}
-              />
-            )}
-          </div>
+      {/* ── Sponsors ──────────────────────────────────────────────── */}
+      <section className="border-b border-border">
+        <div className="container-editorial py-12">
+          <SectionHeader
+            eyebrow="The most prolific"
+            title="Leading sponsors"
+            description="Members who have introduced the most bills this Congress."
+          />
+          {congressDashboard && (
+            <SponsorTable
+              data={congressDashboard.topSponsors}
+              onSponsorClick={(name) => handleDrillDown('sponsor', name)}
+            />
+          )}
         </div>
+      </section>
 
-        {/* Historical Comparison */}
-        <section className="bg-congress-navy-800/50 rounded-xl border border-congress-navy-700 p-6 backdrop-blur-sm">
-          <h2 className="font-display text-xl font-semibold mb-4 flex items-center gap-2">
-            <span className="w-1 h-6 bg-purple-400 rounded-full"></span>
-            Historical Comparison
-          </h2>
-          <HistoricalChart 
+      {/* ── Historical comparison ─────────────────────────────────── */}
+      <section>
+        <div className="container-editorial py-12">
+          <SectionHeader
+            eyebrow="In context"
+            title="Volume across recent Congresses"
+            description="Total bills introduced in each two-year session of Congress on record. Click a bar to switch the view."
+          />
+          <HistoricalChart
             data={allCongressData}
             selectedCongress={selectedCongress}
-            onCongressClick={handleCongressChange}
+            onCongressClick={setSelectedCongress}
           />
-        </section>
-      </main>
-
-      {/* Footer */}
-      <footer className="border-t border-congress-navy-700 mt-12 bg-congress-navy-900/50">
-        <div className="container mx-auto px-4 py-6 text-center text-congress-navy-400 text-sm">
-          <p>Data refreshed daily from Congress.gov • Last updated: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</p>
         </div>
-      </footer>
+      </section>
     </div>
   );
 }
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Section header — used throughout
+ * ───────────────────────────────────────────────────────────────────── */
+
+function SectionHeader({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description?: string;
+}) {
+  return (
+    <header className="mb-6">
+      <p className="label-eyebrow mb-2">{eyebrow}</p>
+      <h2 className="font-serif text-display-sm font-semibold tracking-tight leading-tight">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+      )}
+    </header>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Helpers
+ * ───────────────────────────────────────────────────────────────────── */
 
 function getOrdinalSuffix(num: number): string {
   const j = num % 10;
@@ -219,25 +273,38 @@ function getOrdinalSuffix(num: number): string {
   return 'th';
 }
 
+function getCongressTermYears(congress: number): string | null {
+  // 1st Congress began March 4, 1789. Each Congress is two years.
+  const startYear = 1789 + (congress - 1) * 2;
+  if (startYear < 1789 || startYear > 2200) return null;
+  return `${startYear}–${startYear + 2}`;
+}
+
 function DashboardSkeleton() {
   return (
-    <div className="min-h-screen bg-congress-navy-950">
-      <div className="container mx-auto px-4 py-8">
-        <div className="h-16 bg-congress-navy-800 rounded-lg mb-8 animate-pulse"></div>
-        <div className="grid grid-cols-4 gap-4 mb-8">
-          {[1,2,3,4].map(i => (
-            <div key={i} className="h-24 bg-congress-navy-800 rounded-lg animate-pulse"></div>
-          ))}
-        </div>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {[1,2,3,4].map(i => (
-            <div key={i} className="h-80 bg-congress-navy-800 rounded-lg animate-pulse"></div>
-          ))}
-        </div>
+    <div className="container-editorial py-12 space-y-8">
+      <div className="space-y-3">
+        <div className="h-3 w-32 bg-secondary rounded-sm animate-pulse" />
+        <div className="h-12 w-3/4 bg-secondary rounded-sm animate-pulse" />
+        <div className="h-4 w-2/3 bg-secondary rounded-sm animate-pulse" />
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-px border border-border bg-border">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-24 bg-background animate-pulse" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {[1, 2].map((i) => (
+          <div key={i} className="h-64 bg-secondary rounded-sm animate-pulse" />
+        ))}
       </div>
     </div>
   );
 }
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Stats overview — borderless metric grid
+ * ───────────────────────────────────────────────────────────────────── */
 
 interface StatsOverviewProps {
   stats?: {
@@ -264,63 +331,36 @@ interface StatsOverviewProps {
 function StatsOverview({ stats, dashboardData, onDrillDown }: StatsOverviewProps) {
   if (!stats || !dashboardData) return null;
 
-  const statCards = [
-    {
-      label: 'Total Bills',
-      value: stats.totalCount,
-      color: 'bg-congress-gold-500',
-      textColor: 'text-congress-gold-400',
-      onClick: () => onDrillDown('status', 'all'),
-    },
-    {
-      label: 'House Bills',
-      value: stats.houseCount,
-      color: 'bg-blue-500',
-      textColor: 'text-blue-400',
-      onClick: () => onDrillDown('billType', 'hr'),
-    },
-    {
-      label: 'Senate Bills',
-      value: stats.senateCount,
-      color: 'bg-emerald-500',
-      textColor: 'text-emerald-400',
-      onClick: () => onDrillDown('billType', 's'),
-    },
-    {
-      label: 'Became Law',
-      value: dashboardData.statusBreakdown.becameLaw,
-      color: 'bg-congress-crimson-500',
-      textColor: 'text-congress-crimson-400',
-      onClick: () => onDrillDown('status', 100),
-    },
+  const items = [
+    { label: 'Bills introduced', value: stats.totalCount, onClick: () => onDrillDown('status', 'all') },
+    { label: 'House bills', value: stats.houseCount, onClick: () => onDrillDown('billType', 'hr') },
+    { label: 'Senate bills', value: stats.senateCount, onClick: () => onDrillDown('billType', 's') },
+    { label: 'Became law', value: dashboardData.statusBreakdown.becameLaw, onClick: () => onDrillDown('status', 100) },
   ];
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      {statCards.map((stat, index) => (
+    <dl className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-border border-x border-border">
+      {items.map((item) => (
         <button
-          key={stat.label}
-          onClick={stat.onClick}
-          className="group relative bg-congress-navy-800/80 rounded-xl border border-congress-navy-700 p-5 text-left transition-all duration-300 hover:bg-congress-navy-800 hover:border-congress-gold-500/50 hover:shadow-lg hover:shadow-congress-gold-500/10"
-          style={{ animationDelay: `${index * 0.1}s` }}
+          key={item.label}
+          onClick={item.onClick}
+          className="group text-left px-5 py-4 hover:bg-secondary/60 transition-colors"
         >
-          <div className={`absolute top-0 left-0 w-full h-1 ${stat.color} rounded-t-xl`}></div>
-          <p className="text-congress-navy-400 text-sm font-medium mb-1">{stat.label}</p>
-          <p className={`font-display text-3xl font-bold ${stat.textColor}`}>
-            {stat.value.toLocaleString()}
-          </p>
-          <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
-            <svg className="w-4 h-4 text-congress-gold-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </div>
+          <dt className="label-eyebrow mb-2">{item.label}</dt>
+          <dd className="font-serif text-3xl sm:text-4xl font-semibold tracking-tight tabular text-foreground">
+            {item.value.toLocaleString()}
+          </dd>
         </button>
       ))}
-    </div>
+    </dl>
   );
 }
 
-interface StatusChartProps {
+/* ─────────────────────────────────────────────────────────────────────
+ * Status distribution — horizontal stacked bar (Tufte-style)
+ * ───────────────────────────────────────────────────────────────────── */
+
+interface StatusBarProps {
   data: {
     introduced: number;
     inCommittee: number;
@@ -335,248 +375,182 @@ interface StatusChartProps {
   onSegmentClick: (filterType: string, filterValue: string | number) => void;
 }
 
-function StatusChart({ data, totalBills, onSegmentClick }: StatusChartProps) {
+function StatusBar({ data, totalBills, onSegmentClick }: StatusBarProps) {
   const stages = [
-    { key: 'introduced', label: 'Introduced', color: '#64748b', value: data.introduced },
-    { key: 'inCommittee', label: 'In Committee', color: '#6366f1', value: data.inCommittee },
-    { key: 'passedOneChamber', label: 'Passed One Chamber', color: '#8b5cf6', value: data.passedOneChamber },
-    { key: 'passedBothChambers', label: 'Passed Both Chambers', color: '#a855f7', value: data.passedBothChambers },
-    { key: 'toPresident', label: 'To President', color: '#ec4899', value: data.toPresident },
-    { key: 'signed', label: 'Signed by President', color: '#f43f5e', value: data.signed },
-    { key: 'becameLaw', label: 'Became Law', color: '#22c55e', value: data.becameLaw },
-  ].filter(s => s.value > 0);
+    { key: 'introduced',          label: 'Introduced',           color: 'hsl(var(--status-introduced))', value: data.introduced,          stage: 20 },
+    { key: 'inCommittee',         label: 'In committee',         color: 'hsl(var(--status-committee))',  value: data.inCommittee,         stage: 40 },
+    { key: 'passedOneChamber',    label: 'Passed one chamber',   color: 'hsl(var(--status-passed-one))', value: data.passedOneChamber,    stage: 60 },
+    { key: 'passedBothChambers',  label: 'Passed both chambers', color: 'hsl(var(--status-passed-both))', value: data.passedBothChambers, stage: 80 },
+    { key: 'toPresident',         label: 'To the President',     color: 'hsl(var(--status-president))',  value: data.toPresident,         stage: 90 },
+    { key: 'signed',              label: 'Signed',               color: 'hsl(var(--status-signed))',     value: data.signed,              stage: 95 },
+    { key: 'becameLaw',           label: 'Became law',           color: 'hsl(var(--status-law))',        value: data.becameLaw,           stage: 100 },
+  ].filter((s) => s.value > 0);
 
-  const statusMap: Record<string, number> = {
-    introduced: 20,
-    inCommittee: 40,
-    passedOneChamber: 60,
-    passedBothChambers: 80,
-    toPresident: 90,
-    signed: 95,
-    becameLaw: 100,
-  };
-
-  return (
-    <div className="flex flex-col lg:flex-row items-center gap-6">
-      {/* Donut Chart */}
-      <div className="relative w-48 h-48 shrink-0">
-        <svg viewBox="0 0 100 100" className="w-full h-full transform -rotate-90">
-          {stages.reduce((acc, stage, index) => {
-            const startAngle = acc;
-            const percentage = (stage.value / totalBills) * 100;
-            const angle = (percentage / 100) * 360;
-            const endAngle = startAngle + angle;
-            
-            const startRad = (startAngle - 90) * Math.PI / 180;
-            const endRad = (endAngle - 90) * Math.PI / 180;
-            
-            const x1 = 50 + 35 * Math.cos(startRad);
-            const y1 = 50 + 35 * Math.sin(startRad);
-            const x2 = 50 + 35 * Math.cos(endRad);
-            const y2 = 50 + 35 * Math.sin(endRad);
-            
-            const largeArc = angle > 180 ? 1 : 0;
-            
-            acc += angle;
-            return acc;
-          }, 0)}
-          
-          {stages.reduce((acc, stage, index) => {
-            const startAngle = acc;
-            const percentage = (stage.value / totalBills) * 100;
-            const angle = (percentage / 100) * 360;
-            const endAngle = startAngle + angle;
-            
-            const startRad = (startAngle - 90) * Math.PI / 180;
-            const endRad = (endAngle - 90) * Math.PI / 180;
-            
-            const x1 = 50 + 35 * Math.cos(startRad);
-            const y1 = 50 + 35 * Math.sin(startRad);
-            const x2 = 50 + 35 * Math.cos(endRad);
-            const y2 = 50 + 35 * Math.sin(endRad);
-            
-            const largeArc = angle > 180 ? 1 : 0;
-            
-            return acc + angle;
-          }, 0)}
-          
-          {(() => {
-            let currentAngle = 0;
-            return stages.map((stage, index) => {
-              const percentage = (stage.value / totalBills) * 100;
-              const angle = (percentage / 100) * 360;
-              const startAngle = currentAngle;
-              const endAngle = currentAngle + angle;
-              
-              const startRad = (startAngle - 90) * Math.PI / 180;
-              const endRad = (endAngle - 90) * Math.PI / 180;
-              
-              const x1 = 50 + 35 * Math.cos(startRad);
-              const y1 = 50 + 35 * Math.sin(startRad);
-              const x2 = 50 + 35 * Math.cos(endRad);
-              const y2 = 50 + 35 * Math.sin(endRad);
-              
-              const largeArc = angle > 180 ? 1 : 0;
-              
-              currentAngle = endAngle;
-              
-              return (
-                <path
-                  key={stage.key}
-                  d={`M ${x1} ${y1} A 35 35 0 ${largeArc} 1 ${x2} ${y2}`}
-                  fill="none"
-                  stroke={stage.color}
-                  strokeWidth="18"
-                  className="cursor-pointer transition-all duration-200 hover:stroke-width-20"
-                  onClick={() => onSegmentClick('status', statusMap[stage.key])}
-                />
-              );
-            });
-          })()}
-        </svg>
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className="text-3xl font-display font-bold text-white">{totalBills.toLocaleString()}</span>
-          <span className="text-xs text-congress-navy-400">Total Bills</span>
-        </div>
-      </div>
-
-      {/* Legend */}
-      <div className="flex-1 grid grid-cols-2 gap-2">
-        {stages.map((stage) => (
-          <button
-            key={stage.key}
-            onClick={() => onSegmentClick('status', statusMap[stage.key])}
-            className="flex items-center gap-2 p-2 rounded-lg hover:bg-congress-navy-700/50 transition-colors text-left group"
-          >
-            <span 
-              className="w-3 h-3 rounded-full shrink-0" 
-              style={{ backgroundColor: stage.color }}
-            />
-            <span className="text-sm text-congress-navy-200 group-hover:text-white truncate flex-1">
-              {stage.label}
-            </span>
-            <span className="text-sm font-semibold text-white">
-              {stage.value.toLocaleString()}
-            </span>
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-interface PolicyAreaChartProps {
-  data: Array<{ name: string; count: number }>;
-  onBarClick: (area: string) => void;
-}
-
-function PolicyAreaChart({ data, onBarClick }: PolicyAreaChartProps) {
-  const maxCount = Math.max(...data.map(d => d.count), 1);
-
-  if (data.length === 0) {
-    return (
-      <div className="h-64 flex items-center justify-center text-congress-navy-400">
-        No policy area data available
-      </div>
-    );
+  if (totalBills === 0) {
+    return <p className="text-sm text-muted-foreground">No bill status data available.</p>;
   }
 
   return (
-    <div className="space-y-3">
-      {data.map((item, index) => (
-        <button
-          key={item.name}
-          onClick={() => onBarClick(item.name)}
-          className="w-full group flex items-center gap-3"
-        >
-          <span className="w-24 text-sm text-congress-navy-300 truncate text-left shrink-0">
-            {item.name}
-          </span>
-          <div className="flex-1 h-6 bg-congress-navy-900 rounded-full overflow-hidden">
-            <div 
-              className="h-full bg-gradient-to-r from-congress-crimson-600 to-congress-crimson-400 rounded-full transition-all duration-500 group-hover:shadow-lg group-hover:shadow-congress-crimson-500/20"
-              style={{ width: `${(item.count / maxCount) * 100}%` }}
+    <div className="space-y-5">
+      {/* Stacked horizontal bar */}
+      <div className="flex h-3 w-full overflow-hidden rounded-sm border border-border">
+        {stages.map((s) => {
+          const w = (s.value / totalBills) * 100;
+          if (w <= 0) return null;
+          return (
+            <button
+              key={s.key}
+              onClick={() => onSegmentClick('status', s.stage)}
+              aria-label={`${s.label}: ${s.value} bills`}
+              className="block h-full hover:opacity-80 transition-opacity"
+              style={{ width: `${w}%`, backgroundColor: s.color }}
             />
-          </div>
-          <span className="w-12 text-sm font-semibold text-white text-right shrink-0">
-            {item.count}
-          </span>
-        </button>
-      ))}
+          );
+        })}
+      </div>
+
+      {/* Legend / data table */}
+      <ul className="divide-y divide-border border-y border-border">
+        {stages.map((s) => {
+          const pct = ((s.value / totalBills) * 100).toFixed(1);
+          return (
+            <li key={s.key}>
+              <button
+                onClick={() => onSegmentClick('status', s.stage)}
+                className="grid grid-cols-12 items-center gap-3 w-full py-2.5 px-1 text-left hover:bg-secondary/60 transition-colors group"
+              >
+                <span
+                  className="col-span-1 inline-block h-2.5 w-2.5 rounded-sm shrink-0"
+                  style={{ backgroundColor: s.color }}
+                  aria-hidden="true"
+                />
+                <span className="col-span-7 sm:col-span-7 text-sm text-foreground">
+                  {s.label}
+                </span>
+                <span className="col-span-2 text-right font-mono text-xs text-muted-foreground tabular">
+                  {pct}%
+                </span>
+                <span className="col-span-2 text-right font-mono text-sm font-medium text-foreground tabular">
+                  {s.value.toLocaleString()}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }
 
-interface TimelineChartProps {
-  data: Array<{ stage: string; avgDays: number; description: string }>;
+/* ─────────────────────────────────────────────────────────────────────
+ * Top policy areas — minimal horizontal bar list
+ * ───────────────────────────────────────────────────────────────────── */
+
+interface PolicyAreaListProps {
+  data: Array<{ name: string; count: number }>;
+  onItemClick: (area: string) => void;
 }
 
-function TimelineChart({ data }: TimelineChartProps) {
-  const maxDays = Math.max(...data.map(d => d.avgDays), 1);
+function PolicyAreaList({ data, onItemClick }: PolicyAreaListProps) {
+  if (!data || data.length === 0) {
+    return <p className="text-sm text-muted-foreground">No policy area data available.</p>;
+  }
+  const max = Math.max(...data.map((d) => d.count), 1);
 
   return (
-    <div className="space-y-4">
-      {data.slice(1).map((item, index) => (
-        <div key={item.stage} className="space-y-1">
-          <div className="flex justify-between text-sm">
-            <span className="text-congress-navy-200">{item.description}</span>
-            <span className="text-white font-semibold">
-              {item.avgDays > 0 ? `${item.avgDays} days` : '—'}
-            </span>
-          </div>
-          <div className="h-2 bg-congress-navy-900 rounded-full overflow-hidden">
-            <div 
-              className="h-full bg-gradient-to-r from-blue-600 to-blue-400 rounded-full transition-all duration-700"
-              style={{ width: `${maxDays > 0 ? (item.avgDays / maxDays) * 100 : 0}%` }}
-            />
-          </div>
-        </div>
-      ))}
-    </div>
+    <ol className="space-y-2.5">
+      {data.slice(0, 8).map((item) => {
+        const w = (item.count / max) * 100;
+        return (
+          <li key={item.name}>
+            <button
+              onClick={() => onItemClick(item.name)}
+              className="w-full text-left group"
+            >
+              <div className="flex items-baseline justify-between gap-3 mb-1">
+                <span className="text-sm text-foreground group-hover:underline underline-offset-2 decoration-border truncate">
+                  {item.name}
+                </span>
+                <span className="font-mono text-xs text-muted-foreground tabular shrink-0">
+                  {item.count.toLocaleString()}
+                </span>
+              </div>
+              <div className="h-[3px] w-full bg-secondary overflow-hidden">
+                <div
+                  className="h-full bg-foreground/80 group-hover:bg-foreground transition-colors"
+                  style={{ width: `${w}%` }}
+                />
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ol>
   );
 }
 
-interface SponsorLeaderboardProps {
+/* ─────────────────────────────────────────────────────────────────────
+ * Sponsor leaderboard — proper editorial table
+ * ───────────────────────────────────────────────────────────────────── */
+
+interface SponsorTableProps {
   data: Array<{ name: string; count: number; party?: string; state?: string }>;
   onSponsorClick: (name: string) => void;
 }
 
-function SponsorLeaderboard({ data, onSponsorClick }: SponsorLeaderboardProps) {
-  if (data.length === 0) {
-    return (
-      <div className="h-64 flex items-center justify-center text-congress-navy-400">
-        No sponsor data available
-      </div>
-    );
+function SponsorTable({ data, onSponsorClick }: SponsorTableProps) {
+  if (!data || data.length === 0) {
+    return <p className="text-sm text-muted-foreground">No sponsor data available.</p>;
   }
 
   return (
-    <div className="space-y-2">
-      {data.slice(0, 8).map((sponsor, index) => (
-        <button
-          key={sponsor.name}
-          onClick={() => onSponsorClick(sponsor.name)}
-          className="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-congress-navy-700/50 transition-colors group text-left"
-        >
-          <span className="w-6 h-6 flex items-center justify-center bg-congress-navy-700 rounded-full text-xs font-bold text-congress-gold-400 shrink-0">
-            {index + 1}
-          </span>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-white truncate group-hover:text-congress-gold-400 transition-colors">
-              {sponsor.name}
-            </p>
-            <p className="text-xs text-congress-navy-400">
-              {[sponsor.party, sponsor.state].filter(Boolean).join(' • ')}
-            </p>
-          </div>
-          <span className="text-sm font-bold text-congress-navy-200">
-            {sponsor.count}
-          </span>
-        </button>
-      ))}
+    <div className="border-y border-border">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="label-eyebrow text-left py-2 pr-3 w-8">#</th>
+            <th className="label-eyebrow text-left py-2 pr-3">Member</th>
+            <th className="label-eyebrow text-left py-2 px-3 hidden sm:table-cell">Party</th>
+            <th className="label-eyebrow text-left py-2 px-3 hidden sm:table-cell">State</th>
+            <th className="label-eyebrow text-right py-2 pl-3">Bills</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {data.slice(0, 10).map((s, i) => (
+            <tr
+              key={s.name}
+              className="hover:bg-secondary/50 transition-colors cursor-pointer"
+              onClick={() => onSponsorClick(s.name)}
+            >
+              <td className="py-2.5 pr-3 font-mono text-xs text-muted-foreground tabular">
+                {i + 1}
+              </td>
+              <td className="py-2.5 pr-3 text-sm font-medium text-foreground">
+                {s.name}
+                <span className="ml-2 sm:hidden font-mono text-xs text-muted-foreground">
+                  {[s.party, s.state].filter(Boolean).join(' · ')}
+                </span>
+              </td>
+              <td className="py-2.5 px-3 text-sm text-muted-foreground hidden sm:table-cell">
+                {s.party || '—'}
+              </td>
+              <td className="py-2.5 px-3 text-sm text-muted-foreground hidden sm:table-cell">
+                {s.state || '—'}
+              </td>
+              <td className="py-2.5 pl-3 text-right font-mono text-sm font-medium text-foreground tabular">
+                {s.count.toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Historical comparison — quiet bar chart
+ * ───────────────────────────────────────────────────────────────────── */
 
 interface HistoricalChartProps {
   data: Array<{
@@ -592,65 +566,53 @@ interface HistoricalChartProps {
 
 function HistoricalChart({ data, selectedCongress, onCongressClick }: HistoricalChartProps) {
   if (!data || data.length === 0) {
-    return (
-      <div className="h-48 flex items-center justify-center text-congress-navy-400">
-        No historical data available
-      </div>
-    );
+    return <p className="text-sm text-muted-foreground">No historical data available.</p>;
   }
-
-  const sortedData = [...data].sort((a, b) => a.congress - b.congress);
-  const maxCount = Math.max(...sortedData.map(d => d.totalCount), 1);
-
-  if (sortedData.length === 0) {
-    return (
-      <div className="h-48 flex items-center justify-center text-congress-navy-400">
-        No historical data available
-      </div>
-    );
-  }
+  const sorted = [...data].sort((a, b) => a.congress - b.congress);
+  const max = Math.max(...sorted.map((d) => d.totalCount), 1);
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-end justify-center gap-4 h-48">
-        {sortedData.map((item) => {
-          const heightPercent = (item.totalCount / maxCount) * 100;
-          const heightPx = Math.max((item.totalCount / maxCount) * 160, 10); // Min 10px, max 160px
+    <div className="border-y border-border py-6">
+      <div className="flex items-end justify-between gap-2 sm:gap-4 h-44">
+        {sorted.map((item) => {
+          const heightPct = (item.totalCount / max) * 100;
           const isSelected = item.congress === selectedCongress;
-          
           return (
             <button
               key={item.congress}
               onClick={() => onCongressClick(item.congress)}
-              className="flex flex-col items-center gap-2 group"
+              className="group flex-1 flex flex-col items-center gap-2 min-w-0"
+              aria-label={`${item.congress}th Congress: ${item.totalCount.toLocaleString()} bills`}
             >
-              <span className={`text-lg font-bold ${isSelected ? 'text-congress-gold-400' : 'text-white'} group-hover:text-congress-gold-400 transition-colors`}>
+              <span
+                className={cn(
+                  'font-mono text-[11px] tabular',
+                  isSelected ? 'text-foreground font-semibold' : 'text-muted-foreground'
+                )}
+              >
                 {item.totalCount.toLocaleString()}
               </span>
-              <div 
-                className={`w-12 sm:w-16 rounded-t-lg transition-all duration-300 ${
-                  isSelected 
-                    ? 'bg-gradient-to-t from-congress-gold-600 to-congress-gold-400 shadow-lg shadow-congress-gold-500/30' 
-                    : 'bg-gradient-to-t from-blue-600 to-blue-400 group-hover:from-blue-500 group-hover:to-blue-300'
-                }`}
-                style={{ height: `${heightPx}px` }}
+              <div
+                className={cn(
+                  'w-full max-w-[44px] transition-colors',
+                  isSelected
+                    ? 'bg-foreground'
+                    : 'bg-foreground/30 group-hover:bg-foreground/60'
+                )}
+                style={{ height: `${Math.max(heightPct, 4)}%` }}
               />
-              <span className={`text-sm font-medium ${isSelected ? 'text-congress-gold-400' : 'text-congress-navy-300'}`}>
-                {item.congress}{getOrdinalSuffix(item.congress)}
+              <span
+                className={cn(
+                  'font-mono text-[11px] tabular',
+                  isSelected ? 'text-foreground font-semibold' : 'text-muted-foreground'
+                )}
+              >
+                {item.congress}
+                {getOrdinalSuffix(item.congress)}
               </span>
             </button>
           );
         })}
-      </div>
-      <div className="flex justify-center gap-6 pt-2 border-t border-congress-navy-700">
-        <div className="flex items-center gap-2">
-          <span className="w-3 h-3 bg-blue-500 rounded"></span>
-          <span className="text-sm text-congress-navy-300">House</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="w-3 h-3 bg-emerald-500 rounded"></span>
-          <span className="text-sm text-congress-navy-300">Senate</span>
-        </div>
       </div>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,75 +1,96 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500&family=Source+Sans+3:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,500&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Editorial Modernism — design language
+ * Inspired by serious civic journalism (ProPublica, Economist).
+ * Single accent, restrained palette, typographic hierarchy.
+ * All colours expressed as HSL triplets so Tailwind CSS variables work.
+ */
+
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    
-    --accent: 45 80% 47%;
-    --accent-foreground: 0 0% 100%;
-    
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 45 80% 47%;
-    
-    --radius: 0.5rem;
-    
-    --congress-navy: 222 47% 8%;
-    --congress-gold: 45 80% 47%;
-    --congress-crimson: 350 75% 35%;
-    --congress-slate: 215 20% 25%;
+    /* Surface — warm newsprint */
+    --background: 40 30% 97%;
+    --foreground: 220 15% 12%;
+
+    --card: 40 30% 99%;
+    --card-foreground: 220 15% 12%;
+
+    --popover: 40 30% 99%;
+    --popover-foreground: 220 15% 12%;
+
+    /* Primary — civic ink */
+    --primary: 220 25% 14%;
+    --primary-foreground: 40 30% 98%;
+
+    --secondary: 40 15% 92%;
+    --secondary-foreground: 220 15% 18%;
+
+    --muted: 40 15% 94%;
+    --muted-foreground: 220 8% 42%;
+
+    /* Single accent — deep editorial red (masthead red) */
+    --accent: 358 65% 38%;
+    --accent-foreground: 40 30% 98%;
+
+    --destructive: 358 65% 38%;
+    --destructive-foreground: 40 30% 98%;
+
+    --border: 35 15% 85%;
+    --input: 35 15% 85%;
+    --ring: 220 25% 14%;
+
+    /* Stage / status colours used in dashboard charts */
+    --status-introduced: 220 8% 55%;
+    --status-committee: 220 25% 38%;
+    --status-passed-one: 35 65% 42%;
+    --status-passed-both: 28 70% 45%;
+    --status-president: 18 70% 42%;
+    --status-signed: 358 65% 38%;
+    --status-law: 145 40% 32%;
+
+    --radius: 0.25rem;
   }
 
   .dark {
-    --background: 222 47% 8%;
-    --foreground: 210 40% 98%;
-    
-    --card: 222 47% 11%;
-    --card-foreground: 210 40% 98%;
-    
-    --popover: 222 47% 11%;
-    --popover-foreground: 210 40% 98%;
-    
-    --primary: 45 80% 47%;
-    --primary-foreground: 222 47% 8%;
-    
-    --secondary: 215 20% 20%;
-    --secondary-foreground: 210 40% 98%;
-    
-    --muted: 215 20% 20%;
-    --muted-foreground: 215 20% 70%;
-    
-    --accent: 45 80% 55%;
-    --accent-foreground: 222 47% 8%;
-    
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    
-    --border: 215 20% 25%;
-    --input: 215 20% 25%;
-    --ring: 45 80% 55%;
+    /* Surface — warm dark, like newsprint at night */
+    --background: 220 18% 8%;
+    --foreground: 40 20% 92%;
+
+    --card: 220 18% 11%;
+    --card-foreground: 40 20% 92%;
+
+    --popover: 220 18% 11%;
+    --popover-foreground: 40 20% 92%;
+
+    --primary: 40 20% 92%;
+    --primary-foreground: 220 18% 8%;
+
+    --secondary: 220 12% 18%;
+    --secondary-foreground: 40 20% 92%;
+
+    --muted: 220 12% 16%;
+    --muted-foreground: 40 8% 65%;
+
+    --accent: 358 70% 58%;
+    --accent-foreground: 220 18% 8%;
+
+    --destructive: 358 70% 58%;
+    --destructive-foreground: 220 18% 8%;
+
+    --border: 220 12% 22%;
+    --input: 220 12% 22%;
+    --ring: 40 20% 92%;
+
+    --status-introduced: 220 8% 60%;
+    --status-committee: 220 20% 60%;
+    --status-passed-one: 35 60% 60%;
+    --status-passed-both: 28 65% 60%;
+    --status-president: 18 65% 58%;
+    --status-signed: 358 70% 60%;
+    --status-law: 145 40% 55%;
   }
 }
 
@@ -77,99 +98,76 @@
   * {
     @apply border-border;
   }
-  
+
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
   body {
-    @apply bg-background text-foreground;
-    font-family: 'Source Sans 3', system-ui, sans-serif;
+    @apply bg-background text-foreground font-sans;
+    font-feature-settings: 'kern', 'liga', 'calt';
   }
-  
+
   h1, h2, h3, h4, h5, h6 {
-    font-family: 'Playfair Display', Georgia, serif;
+    @apply font-serif;
+    font-feature-settings: 'kern', 'liga', 'dlig', 'onum';
+    letter-spacing: -0.01em;
+  }
+
+  /* Editorial small caps for labels */
+  .label-eyebrow {
+    @apply text-[11px] font-sans font-semibold uppercase tracking-[0.14em] text-muted-foreground;
+  }
+
+  /* Pull-quote / dropped capital initial */
+  .first-letter-drop::first-letter {
+    @apply font-serif text-foreground;
+    float: left;
+    font-size: 4rem;
+    line-height: 0.9;
+    padding-right: 0.5rem;
+    padding-top: 0.3rem;
+  }
+
+  /* Tabular numerals for data */
+  .tabular {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Subtle horizontal rule used between sections */
+  .rule {
+    @apply border-0 border-t border-border;
   }
 }
 
-@layer utilities {
-  .transform-gpu {
-    transform: translate3d(0, 0, 0);
+@layer components {
+  /* Editorial container — slightly tighter than default */
+  .container-editorial {
+    @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8;
   }
-}
 
-@keyframes slide-up {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+  /* Article reading width */
+  .container-prose {
+    @apply mx-auto w-full max-w-2xl px-4 sm:px-6;
   }
 }
 
 @keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
-@keyframes scale-in {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -200% 0;
-  }
-  100% {
-    background-position: 200% 0;
-  }
+.animate-fade-in {
+  animation: fade-in 0.4s ease-out forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * {
+  *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }
-
-.animate-slide-up {
-  animation: slide-up 0.5s ease-out forwards;
-}
-
-.animate-fade-in {
-  animation: fade-in 0.3s ease-out forwards;
-}
-
-.animate-scale-in {
-  animation: scale-in 0.3s ease-out forwards;
-}
-
-.animate-shimmer {
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
-}
-
-.hardware-accelerated {
-  backface-visibility: hidden;
-  transform: translateZ(0);
-  perspective: 1000px;
-}
-
-.stagger-1 { animation-delay: 0.1s; }
-.stagger-2 { animation-delay: 0.2s; }
-.stagger-3 { animation-delay: 0.3s; }
-.stagger-4 { animation-delay: 0.4s; }
-.stagger-5 { animation-delay: 0.5s; }
-.stagger-6 { animation-delay: 0.6s; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,22 +1,51 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
+import { Fraunces, Inter, JetBrains_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Navigation } from '@/components/navigation';
 import { Footer } from '@/components/footer';
-import { Analytics } from "@vercel/analytics/react"
+import { Analytics } from '@vercel/analytics/react';
 import { Toaster } from '@/components/ui/toaster';
 import { ConvexClientProvider } from './ConvexClientProvider';
+
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-serif',
+  display: 'swap',
+  axes: ['opsz', 'SOFT'],
+});
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});
 
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
+  // Don't disable user zoom — accessibility
+  maximumScale: 5,
+  userScalable: true,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#f6f3ec' },
+    { media: '(prefers-color-scheme: dark)', color: '#16181d' },
+  ],
 };
 
 export const metadata: Metadata = {
-  title: 'Congressional Bill Tracker',
-  description: 'Track and analyze congressional bills with AI-powered insights',
+  title: {
+    default: 'Congressional Bill Tracker',
+    template: '%s · Congressional Bill Tracker',
+  },
+  description:
+    'A clear, independent view of every bill moving through the United States Congress.',
   manifest: '/manifest.ts',
   icons: {
     icon: [
@@ -32,15 +61,13 @@ export const metadata: Metadata = {
       { url: '/icons/icon-512x512.png', sizes: '512x512', type: 'image/png' },
     ],
     shortcut: ['/favicon.png'],
-    apple: [
-      { url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' },
-    ],
+    apple: [{ url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' }],
   },
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',
     title: 'Congressional Bill Tracker',
-  }
+  },
 };
 
 export default function RootLayout({
@@ -49,13 +76,25 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className="font-sans">
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="min-h-screen bg-background text-foreground font-sans antialiased">
         <ConvexClientProvider>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <a
+              href="#main"
+              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded focus:bg-foreground focus:text-background focus:px-3 focus:py-2 focus:text-sm"
+            >
+              Skip to content
+            </a>
             <div className="flex min-h-screen flex-col">
               <Navigation />
-              <main className="flex-1">{children}</main>
+              <main id="main" className="flex-1">
+                {children}
+              </main>
               <Footer />
             </div>
             <Analytics />

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,51 +1,226 @@
-'use client';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { sharedViewport } from '../shared-metadata';
+import type { Metadata, Viewport } from 'next';
 
-import React from 'react';
-import { motion } from 'framer-motion';
-import { CongressSection } from './components/congress-section';
-import { BillsSection } from './components/bills-section';
-import { BillJourneySection } from './components/bill-journey-section';
+export const viewport: Viewport = sharedViewport;
+
+export const metadata: Metadata = {
+  title: 'How Congress works',
+  description:
+    'A short, plain-English guide to the United States Congress and the journey of a bill into law.',
+};
 
 export default function LearnPage() {
   return (
-    <main className="container mx-auto px-4 py-8">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-        className="space-y-16"
-      >
+    <article className="animate-fade-in">
+      {/* Header */}
+      <header className="border-b border-border">
+        <div className="container-editorial py-12 sm:py-16">
+          <p className="label-eyebrow mb-3">A primer</p>
+          <h1 className="font-serif text-display-md sm:text-display-lg font-semibold leading-[1.05] tracking-tight max-w-3xl">
+            How Congress works.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base sm:text-lg text-muted-foreground leading-relaxed">
+            Everything moving through this site is part of one specific
+            process — the writing, debating and passing of federal law. Here is
+            a short guide to what's happening and who is doing it.
+          </p>
 
+          <nav className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <a href="#congress" className="text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground">What Congress is</a>
+            <a href="#chambers" className="text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground">The two chambers</a>
+            <a href="#bills" className="text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground">What a bill is</a>
+            <a href="#journey" className="text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground">A bill's journey</a>
+          </nav>
+        </div>
+      </header>
 
-        <section id="congress">
-          <CongressSection />
-          <div className="border-b border-border my-16" />
-        </section>
+      {/* Body */}
+      <div className="container-editorial py-12 sm:py-16">
+        <div className="container-prose !mx-0 lg:!mx-auto !max-w-2xl space-y-16">
+          <section id="congress" className="space-y-4 scroll-mt-24">
+            <p className="label-eyebrow">§ 01 — Institution</p>
+            <h2 className="font-serif text-display-sm font-semibold tracking-tight">
+              What is Congress?
+            </h2>
+            <p className="font-serif text-lg leading-[1.7] text-foreground first-letter-drop">
+              Congress is the law-making branch of the federal government — the
+              elected body that writes, debates, amends and passes the laws
+              under which the United States operates. It is divided into two
+              chambers, the House of Representatives and the Senate, and meets
+              in the U.S. Capitol in Washington, D.C.
+            </p>
+            <p className="font-serif text-lg leading-[1.7] text-foreground">
+              Each two-year period of work is numbered. The current Congress
+              picks up where the last one left off; bills that didn't make it
+              through must be reintroduced. That's why every bill on this site
+              is tagged with the Congress it belongs to.
+            </p>
+          </section>
 
-        <section id="bills">
-          <BillsSection />
-          <div className="border-b border-border my-16" />
-        </section>
+          <hr className="rule" />
 
-        <section id="journey">
-          <BillJourneySection />
-        </section>
+          <section id="chambers" className="space-y-6 scroll-mt-24">
+            <p className="label-eyebrow">§ 02 — Structure</p>
+            <h2 className="font-serif text-display-sm font-semibold tracking-tight">
+              The two chambers.
+            </h2>
+            <p className="font-serif text-lg leading-[1.7] text-foreground">
+              For a bill to become a law, both the House and the Senate must
+              pass it in identical form. The two chambers serve different — and
+              deliberately countervailing — purposes.
+            </p>
 
-        <motion.div
-          className="fixed bottom-8 right-8"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 1 }}
-        >
-          <a
-            href="#"
-            className="bg-primary text-primary-foreground p-3 rounded-full shadow-lg hover:shadow-xl transition-shadow"
-            aria-label="Back to top"
-          >
-            ↑
-          </a>
-        </motion.div>
-      </motion.div>
-    </main>
+            <div className="grid sm:grid-cols-2 gap-px bg-border border border-border mt-4">
+              {chambers.map((c) => (
+                <div key={c.title} className="bg-background p-6">
+                  <p className="label-eyebrow mb-2">{c.subtitle}</p>
+                  <h3 className="font-serif text-xl font-semibold tracking-tight mb-3">
+                    {c.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed mb-4">
+                    {c.description}
+                  </p>
+                  <dl className="space-y-2 text-sm border-t border-border pt-3">
+                    {c.facts.map((f) => (
+                      <div key={f.label} className="flex justify-between gap-3">
+                        <dt className="text-muted-foreground">{f.label}</dt>
+                        <dd className="text-foreground font-mono tabular text-right">{f.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <hr className="rule" />
+
+          <section id="bills" className="space-y-4 scroll-mt-24">
+            <p className="label-eyebrow">§ 03 — The instrument</p>
+            <h2 className="font-serif text-display-sm font-semibold tracking-tight">
+              What is a bill?
+            </h2>
+            <p className="font-serif text-lg leading-[1.7] text-foreground">
+              A bill is a written proposal for a new law, or for a change to an
+              existing one. It is the basic instrument by which Congress
+              legislates. Bills are written by members of Congress (often with
+              help from staff, lawyers, and outside groups) and introduced
+              into one of the two chambers.
+            </p>
+            <p className="font-serif text-lg leading-[1.7] text-foreground">
+              Most bills die quietly: more than ninety percent never become law.
+              Many are introduced symbolically, to put an idea on the record;
+              others fail in committee. The few that survive may travel for
+              months or years before reaching the President's desk.
+            </p>
+          </section>
+
+          <hr className="rule" />
+
+          <section id="journey" className="space-y-6 scroll-mt-24">
+            <p className="label-eyebrow">§ 04 — Process</p>
+            <h2 className="font-serif text-display-sm font-semibold tracking-tight">
+              A bill's journey, in seven stages.
+            </h2>
+            <p className="font-serif text-lg leading-[1.7] text-foreground">
+              Every bill on this site is tracked through the same set of
+              stages. The progress bar you see on a bill's page corresponds to
+              its position on this path.
+            </p>
+
+            <ol className="mt-2 border-y border-border divide-y divide-border">
+              {stages.map((s, i) => (
+                <li key={s.title} className="grid grid-cols-12 gap-4 py-5">
+                  <div className="col-span-2 sm:col-span-1">
+                    <p className="font-mono text-sm text-muted-foreground tabular pt-0.5">
+                      0{i + 1}
+                    </p>
+                  </div>
+                  <div className="col-span-10 sm:col-span-11">
+                    <h3 className="font-serif text-xl font-semibold tracking-tight mb-1">
+                      {s.title}
+                    </h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      {s.body}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <div className="rule" />
+
+          <section className="text-center py-4">
+            <p className="label-eyebrow mb-3">Now you're ready.</p>
+            <Link
+              href="/bills"
+              className="inline-flex items-center gap-2 rounded-sm bg-foreground px-5 py-3 text-sm font-medium text-background hover:bg-foreground/85 transition-colors"
+            >
+              Browse the bills in Congress
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </section>
+        </div>
+      </div>
+    </article>
   );
-} 
+}
+
+const chambers = [
+  {
+    subtitle: "The People's Chamber",
+    title: 'House of Representatives',
+    description:
+      "Representation by population. Each state's seats are apportioned according to its share of the national population, so larger states have more votes.",
+    facts: [
+      { label: 'Members', value: '435' },
+      { label: 'Term length', value: '2 years' },
+      { label: 'Leader', value: 'Speaker' },
+    ],
+  },
+  {
+    subtitle: "The States' Chamber",
+    title: 'Senate',
+    description:
+      'Equal representation by state. Every state — no matter its size — has exactly two Senators, and one third of the seats come up for election every two years.',
+    facts: [
+      { label: 'Members', value: '100' },
+      { label: 'Term length', value: '6 years' },
+      { label: 'Leader', value: 'Vice President' },
+    ],
+  },
+];
+
+const stages = [
+  {
+    title: 'Introduced',
+    body: 'A member of Congress formally puts the bill on the record in their chamber. The bill receives an official number, like H.R. 1234 (House) or S. 567 (Senate).',
+  },
+  {
+    title: 'In committee',
+    body: 'The bill is referred to one or more standing committees, where most of the substantive work happens — hearings, expert testimony, amendments, and often, quiet death.',
+  },
+  {
+    title: 'Passed one chamber',
+    body: 'If the committee reports the bill out, the full chamber debates and votes on it. A simple majority is enough for passage.',
+  },
+  {
+    title: 'Passed both chambers',
+    body: 'The other chamber repeats the process. If both pass different versions, a conference committee reconciles them into a single text that both chambers must approve again.',
+  },
+  {
+    title: 'To the President',
+    body: 'Once both chambers agree on identical language, the bill is enrolled and sent to the President.',
+  },
+  {
+    title: 'Signed',
+    body: 'The President signs the bill within ten days. (If they do nothing while Congress is in session, it also becomes law. A veto sends it back, where Congress may override with a two-thirds vote in each chamber.)',
+  },
+  {
+    title: 'Became law',
+    body: 'The bill is now an Act, assigned a Public Law number (e.g. PL 118-42), and added to the United States Code.',
+  },
+];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,10 +9,11 @@ const DashboardClient = dynamic(
 
 function LoadingState() {
   return (
-    <div className="min-h-screen bg-[#0a1628] flex items-center justify-center">
-      <div className="text-center">
-        <div className="w-16 h-16 border-4 border-[#c9a227] border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-        <p className="text-[#94a3b8] font-serif text-xl">Loading Congressional Intelligence...</p>
+    <div className="container-editorial py-16 sm:py-24">
+      <div className="space-y-3">
+        <div className="h-3 w-32 bg-secondary rounded-sm animate-pulse" />
+        <div className="h-12 w-3/4 bg-secondary rounded-sm animate-pulse" />
+        <div className="h-4 w-1/2 bg-secondary rounded-sm animate-pulse" />
       </div>
     </div>
   );

--- a/app/shared-metadata.ts
+++ b/app/shared-metadata.ts
@@ -3,11 +3,11 @@ import { Viewport } from 'next';
 export const sharedViewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
+  maximumScale: 5,
+  userScalable: true,
 };
 
 export const sharedThemeColor = [
-  { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-  { media: '(prefers-color-scheme: dark)', color: '#000000' },
+  { media: '(prefers-color-scheme: light)', color: '#f6f3ec' },
+  { media: '(prefers-color-scheme: dark)', color: '#16181d' },
 ]; 

--- a/components/bills/bill-card.tsx
+++ b/components/bills/bill-card.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
 import { Bill } from '@/lib/types/bill';
 import { BillProgress } from './bill-progress';
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 
 interface BillCardProps {
   bill: Bill;
@@ -13,71 +13,92 @@ interface BillCardProps {
 export default function BillCard({ bill }: BillCardProps) {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString + 'T00:00:00Z');
-    
     return new Intl.DateTimeFormat('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
-      timeZone: 'UTC'
+      timeZone: 'UTC',
     }).format(date);
   };
 
-  // Ensure progress_stage is a number
-  const stage = typeof bill.progress_stage === 'string' 
-    ? parseInt(bill.progress_stage, 10) 
-    : bill.progress_stage;
+  const stage =
+    typeof bill.progress_stage === 'string'
+      ? parseInt(bill.progress_stage, 10)
+      : bill.progress_stage;
+
+  // Reconstruct the bill number string (e.g., HR · 1234) from available fields.
+  const billNumberLabel = formatBillNumber(bill);
 
   return (
-    <Link href={`/bills/${bill.id}`}>
-      <Card className="h-full hover:bg-accent/50 transition-colors overflow-hidden group">
-        {/* Top section with policy area and date */}
-        <div className="p-4">
-          <div className="flex justify-between items-baseline mb-2">
-            <div className="text-xs text-muted-foreground">
-              {formatDate(bill.introduced_date)}
-            </div>
-          </div>
-          {bill.bill_subjects?.policy_area_name && (
-            <Badge 
-              variant="outline" 
-              className="transition-all duration-300 group-hover:border-primary group-hover:text-primary"
-            >
-              {bill.bill_subjects.policy_area_name}
-            </Badge>
-          )}
+    <Link
+      href={`/bills/${bill.id}`}
+      className="group block rounded-sm border border-border bg-card hover:border-foreground/40 transition-colors h-full"
+    >
+      <article className="flex flex-col h-full p-5">
+        {/* Header — number + date */}
+        <div className="flex items-baseline justify-between gap-3 mb-3">
+          <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground tabular">
+            {billNumberLabel}
+          </span>
+          <time className="font-mono text-[11px] text-muted-foreground tabular">
+            {formatDate(bill.introduced_date)}
+          </time>
         </div>
 
-        {/* Main content */}
-        <CardContent className="space-y-4 p-4 pt-0">
-          {/* Title with truncation */}
-          <h3 className="font-medium leading-snug line-clamp-2 min-h-[48px]">
-            {bill.title}
-          </h3>
+        {/* Title */}
+        <h3 className="font-serif text-lg font-semibold leading-snug tracking-tight text-foreground line-clamp-3 min-h-[4.5rem] group-hover:underline underline-offset-4 decoration-border">
+          {bill.title}
+        </h3>
 
-          {/* Progress bar */}
-          <BillProgress
-            stage={stage}
-            description={bill.progress_description}
-          />
-
-          {/* Sponsor info */}
-          <div className="flex items-center gap-2 pt-2">
-            <div className="h-8 w-8 rounded-full bg-accent flex items-center justify-center">
-              <span className="text-sm font-medium">
-                {bill.sponsor_first_name[0]}{bill.sponsor_last_name[0]}
-              </span>
-            </div>
-            <div className="flex-1">
-              <div className="text-sm font-medium">
-                {bill.sponsor_first_name} {bill.sponsor_last_name}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                Primary Sponsor
-              </div>
-            </div>
+        {/* Policy area */}
+        {bill.bill_subjects?.policy_area_name && (
+          <div className="mt-3">
+            <Badge variant="muted">{bill.bill_subjects.policy_area_name}</Badge>
           </div>
-        </CardContent>
-      </Card>
+        )}
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Progress */}
+        <div className="mt-5">
+          <BillProgress stage={stage} description={bill.progress_description} />
+        </div>
+
+        {/* Footer — sponsor */}
+        <div className="mt-4 pt-4 border-t border-border flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+              Sponsor
+            </p>
+            <p className="text-sm font-medium text-foreground truncate">
+              {bill.sponsor_first_name} {bill.sponsor_last_name}
+              {bill.sponsor_party && bill.sponsor_state && (
+                <span className="font-mono text-xs text-muted-foreground tabular">
+                  {' '}· {bill.sponsor_party}-{bill.sponsor_state}
+                </span>
+              )}
+            </p>
+          </div>
+          <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground group-hover:translate-x-0.5 transition-all shrink-0" />
+        </div>
+      </article>
     </Link>
   );
+}
+
+function formatBillNumber(bill: Bill): string {
+  if (bill.bill_type && bill.bill_number) {
+    return `${bill.bill_type.toUpperCase()} ${bill.bill_number} · ${bill.congress}${ordinal(bill.congress)}`;
+  }
+  return typeof bill.id === 'string' ? bill.id.replace(/-/g, ' · ').toUpperCase() : 'BILL';
+}
+
+function ordinal(n: number): string {
+  const j = n % 10;
+  const k = n % 100;
+  if (j === 1 && k !== 11) return 'st';
+  if (j === 2 && k !== 12) return 'nd';
+  if (j === 3 && k !== 13) return 'rd';
+  return 'th';
 }

--- a/components/bills/bill-details.tsx
+++ b/components/bills/bill-details.tsx
@@ -3,11 +3,18 @@
 import Link from 'next/link';
 import type { Bill } from '@/lib/types/bill';
 import { useEffect, useState } from 'react';
-import { getStageDescription, getStagePercentage, getProgressDots } from '@/lib/utils/bill-stages';
-import { isValidStage, BillStages } from '@/lib/utils/bill-stages';
+import {
+  getStageDescription,
+  getStagePercentage,
+  getProgressDots,
+  isValidStage,
+  BillStages,
+} from '@/lib/utils/bill-stages';
 import BillQA from './bill-qa';
+import { ArrowLeft, FileText, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 
-// Map of state abbreviations to full names
 const STATE_NAMES: Record<string, string> = {
   AL: 'Alabama', AK: 'Alaska', AZ: 'Arizona', AR: 'Arkansas',
   CA: 'California', CO: 'Colorado', CT: 'Connecticut', DE: 'Delaware',
@@ -21,10 +28,9 @@ const STATE_NAMES: Record<string, string> = {
   OR: 'Oregon', PA: 'Pennsylvania', RI: 'Rhode Island', SC: 'South Carolina',
   SD: 'South Dakota', TN: 'Tennessee', TX: 'Texas', UT: 'Utah',
   VT: 'Vermont', VA: 'Virginia', WA: 'Washington', WV: 'West Virginia',
-  WI: 'Wisconsin', WY: 'Wyoming', DC: 'District of Columbia'
-} as const;
+  WI: 'Wisconsin', WY: 'Wyoming', DC: 'District of Columbia',
+};
 
-// Map of party abbreviations to full names
 const PARTY_NAMES: Record<string, string> = {
   R: 'Republican',
   D: 'Democrat',
@@ -33,9 +39,8 @@ const PARTY_NAMES: Record<string, string> = {
   IR: 'Independent Republican',
   L: 'Libertarian',
   G: 'Green Party',
-  // Fallback for unknown parties
-  '': 'No Party Affiliation'
-} as const;
+  '': 'No Party Affiliation',
+};
 
 interface BillDetailsProps {
   bill: Bill;
@@ -43,7 +48,7 @@ interface BillDetailsProps {
 
 export default function BillDetails({ bill }: BillDetailsProps) {
   const [summary, setSummary] = useState<string>(bill.latest_summary || 'No summary available.');
-  
+
   useEffect(() => {
     try {
       if (bill.latest_summary) {
@@ -51,139 +56,255 @@ export default function BillDetails({ bill }: BillDetailsProps) {
         tmp.innerHTML = bill.latest_summary;
         setSummary(tmp.textContent || tmp.innerText || 'No summary available.');
       }
-    } catch (error: unknown) {
-      console.error('Error parsing bill summary:', error);
+    } catch (e) {
+      console.error('Error parsing bill summary:', e);
       setSummary('Error loading summary.');
     }
   }, [bill.latest_summary]);
 
-  // Convert progress_stage to number and calculate percentage
-  const progressStage = typeof bill.progress_stage === 'string' 
-    ? parseInt(bill.progress_stage, 10) 
-    : bill.progress_stage;
-
-  // Get stage information using utility functions
+  const progressStage =
+    typeof bill.progress_stage === 'string'
+      ? parseInt(bill.progress_stage, 10)
+      : bill.progress_stage;
   const progressPercentage = getStagePercentage(progressStage);
   const displayDescription = getStageDescription(progressStage);
-  const progressDots = isValidStage(progressStage) 
-    ? getProgressDots(progressStage) 
+  const progressDots = isValidStage(progressStage)
+    ? getProgressDots(progressStage)
     : getProgressDots(BillStages.INTRODUCED);
 
-  const stateName = STATE_NAMES[bill.sponsor_state as keyof typeof STATE_NAMES] || bill.sponsor_state;
-  const partyName = PARTY_NAMES[bill.sponsor_party as keyof typeof PARTY_NAMES] || bill.sponsor_party;
+  const stateName = STATE_NAMES[bill.sponsor_state] || bill.sponsor_state;
+  const partyName = PARTY_NAMES[bill.sponsor_party] || bill.sponsor_party;
 
-  // Format date in UTC
   const formatDate = (dateString: string) => {
     const date = new Date(dateString + 'T00:00:00Z');
-    
     return new Intl.DateTimeFormat('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      timeZone: 'UTC'
+      timeZone: 'UTC',
     }).format(date);
   };
 
+  const billLabel = `${bill.bill_type_label || bill.bill_type?.toUpperCase()} ${bill.bill_number}`;
+
   return (
-    <main className="container mx-auto px-4 py-4 sm:py-6 max-w-5xl">
-      {/* Header Section */}
-      <div className="bg-card rounded-lg shadow-lg p-4 sm:p-6 mb-3 sm:mb-4">
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-xl sm:text-3xl font-semibold text-primary leading-tight">{bill.title}</h1>
-          {bill.pdf_url && (
-            <a
-              href={bill.pdf_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="lucide lucide-file-text"
-              >
-                <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-                <polyline points="14 2 14 8 20 8" />
-                <line x1="16" x2="8" y1="13" y2="13" />
-                <line x1="16" x2="8" y1="17" y2="17" />
-                <line x1="10" x2="8" y1="9" y2="9" />
-              </svg>
-              PDF
-            </a>
-          )}
-        </div>
-        <div className="text-sm text-muted-foreground">
-          Introduced on {formatDate(bill.introduced_date)}
-        </div>
-      </div>
+    <article className="animate-fade-in">
+      {/* ── Article header ──────────────────────────────────────── */}
+      <header className="border-b border-border">
+        <div className="container-editorial pt-6 pb-10 sm:pt-8 sm:pb-14">
+          <Link
+            href="/bills"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            All bills
+          </Link>
 
-      {/* Status Section */}
-      <div className="bg-card rounded-lg shadow-lg p-4 sm:p-6 mb-3 sm:mb-4">
-        <h2 className="text-lg sm:text-xl font-semibold mb-4">Current Status</h2>
-        <div className="space-y-3">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-            <span className="text-base font-medium">{displayDescription}</span>
-            <span className="text-sm text-muted-foreground">{progressPercentage}%</span>
-          </div>
-          <div className="w-full bg-secondary rounded-full h-2.5 overflow-hidden">
-            <div
-              className="h-full bg-primary transition-all duration-500 ease-in-out rounded-full"
-              style={{ width: `${progressPercentage}%` }}
-            />
-          </div>
-          {/* Mobile: Vertical stages */}
-          <div className="block sm:hidden space-y-2 text-xs text-muted-foreground mt-2">
-            {progressDots.map(({ stage, isComplete }) => (
-              <div key={stage} className="flex items-center">
-                <div className={`w-1.5 h-1.5 rounded-full mr-2 ${isComplete ? 'bg-primary' : 'bg-secondary'}`} />
-                <span>{stage}</span>
-              </div>
-            ))}
-          </div>
-          {/* Desktop: Horizontal stages */}
-          <div className="hidden sm:flex justify-between text-xs text-muted-foreground">
-            {progressDots.map(({ stage }) => (
-              <span key={stage}>{stage}</span>
-            ))}
+          <div className="max-w-3xl">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 mb-4">
+              <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground tabular">
+                {billLabel} · {bill.congress}th Congress
+              </span>
+              {bill.bill_subjects?.policy_area_name && (
+                <Badge variant="muted">{bill.bill_subjects.policy_area_name}</Badge>
+              )}
+            </div>
+
+            <h1 className="font-serif text-display-md sm:text-display-lg font-semibold leading-[1.08] tracking-tight">
+              {bill.title}
+            </h1>
+
+            <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground">
+              <span>
+                Introduced <span className="text-foreground">{formatDate(bill.introduced_date)}</span>
+              </span>
+              <span className="hidden sm:inline">·</span>
+              <span>
+                By{' '}
+                <span className="text-foreground font-medium">
+                  {bill.sponsor_first_name} {bill.sponsor_last_name}
+                </span>{' '}
+                {bill.sponsor_party && bill.sponsor_state && (
+                  <span className="font-mono tabular">
+                    ({bill.sponsor_party}-{bill.sponsor_state})
+                  </span>
+                )}
+              </span>
+              {bill.pdf_url && (
+                <>
+                  <span className="hidden sm:inline">·</span>
+                  <a
+                    href={bill.pdf_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground"
+                  >
+                    <FileText className="h-3.5 w-3.5" />
+                    Read full text (PDF)
+                  </a>
+                </>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </header>
 
-      {/* Summary Section */}
-      <div className="bg-card rounded-lg shadow-lg p-4 sm:p-6 mb-3 sm:mb-4">
-        <h2 className="text-lg sm:text-xl font-semibold mb-3">Summary</h2>
-        <div className="prose prose-sm max-w-none text-base leading-relaxed text-muted-foreground">
-          {summary}
-        </div>
-      </div>
+      {/* ── Status pipeline ─────────────────────────────────────── */}
+      <section className="border-b border-border bg-secondary/30">
+        <div className="container-editorial py-8">
+          <div className="grid lg:grid-cols-3 gap-8 items-start">
+            <div>
+              <p className="label-eyebrow mb-2">Current status</p>
+              <p className="font-serif text-2xl font-semibold tracking-tight leading-tight">
+                {displayDescription}
+              </p>
+              <p className="mt-1 font-mono text-sm text-muted-foreground tabular">
+                {progressPercentage}% through the legislative process
+              </p>
+            </div>
 
-      {/* Sponsor Information */}
-      <div className="bg-card rounded-lg shadow-lg p-4 sm:p-6">
-        <h2 className="text-lg sm:text-xl font-semibold mb-4">Sponsor Information</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div>
-            <h3 className="text-sm font-medium text-muted-foreground mb-1">Name</h3>
-            <p className="text-base">{`${bill.sponsor_first_name} ${bill.sponsor_last_name}`}</p>
-          </div>
-          <div>
-            <h3 className="text-sm font-medium text-muted-foreground mb-1">Party</h3>
-            <p className="text-base">{partyName}</p>
-          </div>
-          <div>
-            <h3 className="text-sm font-medium text-muted-foreground mb-1">State</h3>
-            <p className="text-base">{stateName}</p>
+            <div className="lg:col-span-2">
+              <ProgressPipeline dots={progressDots} percentage={progressPercentage} />
+            </div>
           </div>
         </div>
-      </div>
+      </section>
 
-      <BillQA billId={bill.id} />
-    </main>
+      {/* ── Body: summary + sponsor sidebar ─────────────────────── */}
+      <section className="container-editorial py-12 sm:py-16">
+        <div className="grid lg:grid-cols-12 gap-10 lg:gap-16">
+          <div className="lg:col-span-8">
+            <p className="label-eyebrow mb-3">Plain-English summary</p>
+            <div className="font-serif text-lg leading-[1.7] text-foreground whitespace-pre-wrap">
+              {summary}
+            </div>
+          </div>
+
+          <aside className="lg:col-span-4 space-y-8 lg:border-l lg:border-border lg:pl-10">
+            <div>
+              <p className="label-eyebrow mb-3">Sponsor</p>
+              <p className="font-serif text-xl font-semibold tracking-tight">
+                {bill.sponsor_first_name} {bill.sponsor_last_name}
+              </p>
+              <dl className="mt-4 space-y-3 text-sm">
+                <div className="flex justify-between gap-3 border-b border-border pb-2">
+                  <dt className="text-muted-foreground">Party</dt>
+                  <dd className="text-foreground font-medium">{partyName}</dd>
+                </div>
+                <div className="flex justify-between gap-3 border-b border-border pb-2">
+                  <dt className="text-muted-foreground">State</dt>
+                  <dd className="text-foreground font-medium">{stateName}</dd>
+                </div>
+                <div className="flex justify-between gap-3 border-b border-border pb-2">
+                  <dt className="text-muted-foreground">Bill number</dt>
+                  <dd className="text-foreground font-mono tabular">
+                    {bill.bill_type?.toUpperCase()} {bill.bill_number}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">Congress</dt>
+                  <dd className="text-foreground font-mono tabular">{bill.congress}th</dd>
+                </div>
+              </dl>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      {/* ── Q&A ────────────────────────────────────────────────── */}
+      <section className="border-t border-border bg-secondary/30">
+        <div className="container-editorial py-12 sm:py-16">
+          <div className="max-w-3xl">
+            <p className="label-eyebrow mb-3">Ask the record</p>
+            <h2 className="font-serif text-display-sm font-semibold tracking-tight mb-2">
+              Have a question about this bill?
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed mb-6">
+              Get plain-English answers grounded in the bill's full text.
+            </p>
+            <BillQA billId={bill.id} />
+          </div>
+        </div>
+      </section>
+    </article>
   );
-} 
+}
+
+/* Editorial pipeline visualisation: dots on a horizontal line */
+function ProgressPipeline({
+  dots,
+  percentage,
+}: {
+  dots: Array<{ stage: string; isComplete: boolean }>;
+  percentage: number;
+}) {
+  return (
+    <div>
+      {/* Horizontal pipeline (sm+) */}
+      <ol className="hidden sm:block">
+        <div className="relative">
+          {/* base line */}
+          <div className="absolute left-2 right-2 top-2 h-px bg-border" aria-hidden="true" />
+          {/* progress line */}
+          <div
+            className="absolute left-2 top-2 h-px bg-foreground transition-all duration-500"
+            style={{ width: `calc((100% - 1rem) * ${percentage / 100})` }}
+            aria-hidden="true"
+          />
+          <div className="flex items-start justify-between gap-1">
+            {dots.map(({ stage, isComplete }) => (
+              <li
+                key={stage}
+                className="relative flex flex-col items-center text-center"
+                style={{ flex: '1 1 0' }}
+              >
+                <span
+                  className={cn(
+                    'flex h-4 w-4 items-center justify-center rounded-full border bg-background z-10',
+                    isComplete
+                      ? 'border-foreground bg-foreground text-background'
+                      : 'border-border'
+                  )}
+                  aria-hidden="true"
+                >
+                  {isComplete && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
+                </span>
+                <span
+                  className={cn(
+                    'mt-2 text-[11px] leading-tight max-w-[8ch]',
+                    isComplete ? 'text-foreground font-medium' : 'text-muted-foreground'
+                  )}
+                >
+                  {stage}
+                </span>
+              </li>
+            ))}
+          </div>
+        </div>
+      </ol>
+
+      {/* Vertical pipeline (mobile) */}
+      <ol className="sm:hidden space-y-2.5">
+        {dots.map(({ stage, isComplete }) => (
+          <li key={stage} className="flex items-center gap-3">
+            <span
+              className={cn(
+                'flex h-3 w-3 items-center justify-center rounded-full border shrink-0',
+                isComplete ? 'border-foreground bg-foreground' : 'border-border'
+              )}
+              aria-hidden="true"
+            />
+            <span
+              className={cn(
+                'text-sm',
+                isComplete ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              {stage}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/components/bills/bill-progress.tsx
+++ b/components/bills/bill-progress.tsx
@@ -1,25 +1,36 @@
 'use client';
 
-import { Progress } from '@/components/ui/progress';
-import { getStageDescription, getStagePercentage, isValidStage, BillStages } from '@/lib/utils/bill-stages';
+import { getStageDescription, getStagePercentage } from '@/lib/utils/bill-stages';
 
 interface BillProgressProps {
   stage: number;
   description: string;
 }
 
-export function BillProgress({ stage, description }: BillProgressProps) {
-  // Get stage information using utility functions
+export function BillProgress({ stage }: BillProgressProps) {
   const displayDescription = getStageDescription(stage);
   const progressPercentage = getStagePercentage(stage);
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <span className="text-sm text-muted-foreground">Status:</span>
-        <span className="text-sm">{displayDescription}</span>
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="label-eyebrow">Status</span>
+        <span className="font-mono text-[11px] text-muted-foreground tabular">
+          {progressPercentage}%
+        </span>
       </div>
-      <Progress value={progressPercentage} className="h-3" />
+      <p className="text-[13px] font-medium text-foreground leading-tight">
+        {displayDescription}
+      </p>
+      <div className="h-[3px] w-full bg-secondary overflow-hidden">
+        <div
+          className="h-full bg-foreground transition-transform duration-500 ease-out"
+          style={{
+            transform: `scaleX(${progressPercentage / 100})`,
+            transformOrigin: 'left',
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/components/bills/bill-qa.tsx
+++ b/components/bills/bill-qa.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { billsService } from '@/lib/services/bills-service';
 import ReactMarkdown from 'react-markdown';
+import { ArrowUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface Message {
   id: string;
@@ -15,10 +17,10 @@ interface BillQAProps {
 }
 
 const EXAMPLE_QUESTIONS = [
-  "What does this bill do in simple terms?",
-  "What is the current status and what's next?",
-  "Who supports or opposes this bill?",
-  "What are the key sections of this bill?",
+  'What does this bill do in simple terms?',
+  "What's the current status and what's next?",
+  'Who supports or opposes this bill?',
+  'What are the key sections of this bill?',
 ];
 
 function generateSessionId(): string {
@@ -39,19 +41,19 @@ function getOrCreateSessionId(): string {
 const MarkdownMessage = ({ content }: { content: string }) => (
   <ReactMarkdown
     components={{
-      p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-      ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
-      ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
-      li: ({ children }) => <li className="ml-1">{children}</li>,
-      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      p: ({ children }) => <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>,
+      ul: ({ children }) => <ul className="list-disc list-outside ml-5 mb-2 space-y-1">{children}</ul>,
+      ol: ({ children }) => <ol className="list-decimal list-outside ml-5 mb-2 space-y-1">{children}</ol>,
+      li: ({ children }) => <li>{children}</li>,
+      strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
       em: ({ children }) => <em className="italic">{children}</em>,
-      h1: ({ children }) => <h1 className="text-base font-bold mt-3 mb-1">{children}</h1>,
-      h2: ({ children }) => <h2 className="text-sm font-semibold mt-2 mb-1">{children}</h2>,
-      h3: ({ children }) => <h3 className="text-sm font-medium mt-2 mb-1">{children}</h3>,
+      h1: ({ children }) => <h3 className="font-serif text-base font-semibold mt-3 mb-1.5">{children}</h3>,
+      h2: ({ children }) => <h3 className="font-serif text-base font-semibold mt-3 mb-1.5">{children}</h3>,
+      h3: ({ children }) => <h3 className="font-serif text-sm font-semibold mt-2 mb-1">{children}</h3>,
       a: ({ href, children }) => (
         <a
           href={href}
-          className="text-primary underline underline-offset-2"
+          className="text-foreground underline underline-offset-2 decoration-border hover:decoration-foreground"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -66,19 +68,10 @@ const MarkdownMessage = ({ content }: { content: string }) => (
 
 const TypingIndicator = () => (
   <div className="flex justify-start">
-    <div className="bg-muted rounded-2xl rounded-bl-sm px-4 py-3 flex items-center gap-1.5">
-      <span
-        className="w-2 h-2 rounded-full bg-muted-foreground/60 animate-bounce"
-        style={{ animationDelay: '0ms' }}
-      />
-      <span
-        className="w-2 h-2 rounded-full bg-muted-foreground/60 animate-bounce"
-        style={{ animationDelay: '160ms' }}
-      />
-      <span
-        className="w-2 h-2 rounded-full bg-muted-foreground/60 animate-bounce"
-        style={{ animationDelay: '320ms' }}
-      />
+    <div className="rounded-sm border border-border bg-card px-4 py-3 flex items-center gap-1.5">
+      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/60 animate-bounce" style={{ animationDelay: '0ms' }} />
+      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/60 animate-bounce" style={{ animationDelay: '160ms' }} />
+      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/60 animate-bounce" style={{ animationDelay: '320ms' }} />
     </div>
   </div>
 );
@@ -94,7 +87,6 @@ export default function BillQA({ billId }: BillQAProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Initialise session and load persisted history on mount
   useEffect(() => {
     const sid = getOrCreateSessionId();
     setSessionId(sid);
@@ -102,21 +94,12 @@ export default function BillQA({ billId }: BillQAProps) {
     billsService
       .getBillChatHistory(billId, sid)
       .then((history) => {
-        setMessages(
-          history.map((m) => ({
-            id: m._id,
-            role: m.role,
-            content: m.content,
-          }))
-        );
+        setMessages(history.map((m) => ({ id: m._id, role: m.role, content: m.content })));
       })
-      .catch(() => {
-        // History fetch failure is non-fatal — start fresh
-      })
+      .catch(() => {})
       .finally(() => setIsLoadingHistory(false));
   }, [billId]);
 
-  // Scroll to the latest message
   useEffect(() => {
     if (!isLoadingHistory) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -138,7 +121,6 @@ export default function BillQA({ billId }: BillQAProps) {
         const result = await billsService.sendChatMessage(billId, sessionId, q);
         if (result.error) {
           setError(result.error);
-          // Remove the optimistic user message on error
           setMessages((prev) => prev.filter((m) => m.id !== tempId));
         } else {
           setMessages((prev) => [
@@ -161,37 +143,36 @@ export default function BillQA({ billId }: BillQAProps) {
   const questionCount = messages.filter((m) => m.role === 'user').length;
 
   return (
-    <div className="bg-card rounded-lg shadow-lg mt-4 flex flex-col overflow-hidden" style={{ height: '520px' }}>
-      {/* ── Header ─────────────────────────────────────────────────── */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b shrink-0">
-        <div className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
-        <h2 className="text-base font-semibold">Ask about this bill</h2>
+    <div className="rounded-sm border border-border bg-background flex flex-col overflow-hidden" style={{ height: '540px' }}>
+      <div className="flex items-center justify-between gap-2 px-5 py-3 border-b border-border shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="h-1.5 w-1.5 rounded-full bg-status-law" aria-hidden="true" />
+          <p className="label-eyebrow !mb-0">Bill chat</p>
+        </div>
         {questionCount > 0 && (
-          <span className="text-xs text-muted-foreground ml-auto">
+          <span className="font-mono text-[11px] text-muted-foreground tabular">
             {questionCount} {questionCount === 1 ? 'question' : 'questions'}
           </span>
         )}
       </div>
 
-      {/* ── Messages ───────────────────────────────────────────────── */}
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3 min-h-0">
+      <div className="flex-1 overflow-y-auto px-5 py-5 space-y-3 min-h-0">
         {isLoadingHistory ? (
           <div className="flex justify-center items-center h-full">
-            <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary border-t-transparent" />
+            <div className="animate-spin rounded-full h-5 w-5 border-2 border-foreground border-t-transparent" />
           </div>
         ) : isEmpty ? (
-          /* Empty state: example questions */
           <div className="flex flex-col items-center justify-center h-full text-center px-2">
-            <p className="text-sm text-muted-foreground mb-4">
-              Ask any question about this bill. Try one of these:
+            <p className="text-sm text-muted-foreground mb-5 max-w-sm leading-relaxed">
+              Ask any question about this bill — its provisions, status, sponsors, or impact.
             </p>
-            <div className="flex flex-col sm:flex-row flex-wrap gap-2 justify-center max-w-lg">
+            <div className="flex flex-col gap-1.5 w-full max-w-md">
               {EXAMPLE_QUESTIONS.map((q, i) => (
                 <button
                   key={i}
                   onClick={() => handleSubmit(q)}
                   disabled={isLoading}
-                  className="px-3 py-2 text-sm bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors text-left sm:text-center disabled:opacity-50"
+                  className="px-3 py-2.5 text-sm text-left rounded-sm border border-border text-foreground hover:bg-secondary transition-colors disabled:opacity-50"
                 >
                   {q}
                 </button>
@@ -201,29 +182,22 @@ export default function BillQA({ billId }: BillQAProps) {
         ) : (
           <>
             {messages.map((message) => (
-              <div
-                key={message.id}
-                className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
-              >
+              <div key={message.id} className={cn('flex', message.role === 'user' ? 'justify-end' : 'justify-start')}>
                 <div
-                  className={`max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                  className={cn(
+                    'max-w-[85%] rounded-sm px-4 py-2.5 text-sm leading-relaxed',
                     message.role === 'user'
-                      ? 'bg-primary text-primary-foreground rounded-br-sm'
-                      : 'bg-muted text-foreground rounded-bl-sm'
-                  }`}
-                >
-                  {message.role === 'assistant' ? (
-                    <MarkdownMessage content={message.content} />
-                  ) : (
-                    <p>{message.content}</p>
+                      ? 'bg-foreground text-background'
+                      : 'border border-border bg-card text-foreground'
                   )}
+                >
+                  {message.role === 'assistant' ? <MarkdownMessage content={message.content} /> : <p>{message.content}</p>}
                 </div>
               </div>
             ))}
 
             {isLoading && <TypingIndicator />}
 
-            {/* Example chips shown after first message for quick follow-ups */}
             {!isLoading && messages.length > 0 && messages.length < 4 && (
               <div className="flex flex-wrap gap-1.5 pt-1">
                 {EXAMPLE_QUESTIONS.filter(
@@ -235,7 +209,7 @@ export default function BillQA({ billId }: BillQAProps) {
                       key={i}
                       onClick={() => handleSubmit(q)}
                       disabled={isLoading}
-                      className="px-2.5 py-1 text-xs bg-secondary text-secondary-foreground rounded-full hover:bg-secondary/80 transition-colors disabled:opacity-50"
+                      className="px-2.5 py-1 text-[12px] border border-border rounded-sm text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors disabled:opacity-50"
                     >
                       {q}
                     </button>
@@ -247,7 +221,7 @@ export default function BillQA({ billId }: BillQAProps) {
 
         {error && (
           <div className="flex justify-center">
-            <div className="px-3 py-2 bg-destructive/10 border border-destructive/20 rounded-lg max-w-sm text-center">
+            <div className="px-3 py-2 border border-destructive/30 bg-destructive/5 rounded-sm max-w-sm text-center">
               <p className="text-sm text-destructive">{error}</p>
             </div>
           </div>
@@ -256,37 +230,34 @@ export default function BillQA({ billId }: BillQAProps) {
         <div ref={messagesEndRef} />
       </div>
 
-      {/* ── Input bar ──────────────────────────────────────────────── */}
-      <div className="border-t px-4 py-3 shrink-0">
+      <div className="border-t border-border px-5 py-3 shrink-0">
         <form
           onSubmit={(e) => {
             e.preventDefault();
             handleSubmit(input);
           }}
-          className="flex gap-2"
+          className="flex items-center gap-2"
         >
           <input
             ref={inputRef}
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder={isEmpty ? 'Ask a question about this bill…' : 'Ask a follow-up question…'}
-            className="flex-1 px-3 py-2 text-sm rounded-lg border border-input bg-background focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
+            placeholder={isEmpty ? 'Ask a question…' : 'Ask a follow-up…'}
+            className="flex-1 h-10 px-3 text-sm rounded-sm border border-border bg-background text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:border-foreground"
             disabled={isLoading || isLoadingHistory}
             maxLength={500}
           />
           <button
             type="submit"
             disabled={isLoading || isLoadingHistory || !input.trim()}
-            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+            aria-label="Send"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-sm bg-foreground text-background hover:bg-foreground/85 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
           >
             {isLoading ? (
-              <span className="flex items-center gap-1.5">
-                <span className="animate-spin rounded-full h-3.5 w-3.5 border-2 border-primary-foreground border-t-transparent" />
-                <span>Thinking</span>
-              </span>
+              <span className="animate-spin rounded-full h-3.5 w-3.5 border-2 border-background border-t-transparent" />
             ) : (
-              'Send'
+              <ArrowUp className="h-4 w-4" />
             )}
           </button>
         </form>

--- a/components/bills/bills-filter.tsx
+++ b/components/bills/bills-filter.tsx
@@ -9,81 +9,72 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
-import { BILL_TYPES } from '@/lib/constants/filters';
 import dynamic from 'next/dynamic';
-import { BillStageDescriptions, BillStageOrder } from '@/lib/utils/bill-stages';
-import { BillStages } from '@/lib/utils/bill-stages';
 import { useState, useEffect } from 'react';
 import { billsService } from '@/lib/services/bills-service';
-import { cn } from "@/lib/utils";
-import { Badge } from "@/components/ui/badge";
-import { Circle } from "lucide-react";
+import { cn } from '@/lib/utils';
 
-// Map of policy areas
 const POLICY_AREAS = [
-  'Agriculture and Food',
-  'Animals',
-  'Armed Forces and National Security',
-  'Arts, Culture, Religion',
-  'Civil Rights and Liberties, Minority Issues',
-  'Commerce',
-  'Congress',
-  'Crime and Law Enforcement',
-  'Economics and Public Finance',
-  'Education',
-  'Emergency Management',
-  'Energy',
-  'Environmental Protection',
-  'Families',
-  'Finance and Financial Sector',
-  'Foreign Trade and International Finance',
-  'Government Operations and Politics',
-  'Health',
-  'Housing and Community Development',
-  'Immigration',
-  'International Affairs',
-  'Labor and Employment',
-  'Law',
-  'Native Americans',
-  'Private Legislation',
-  'Public Lands and Natural Resources',
-  'Science, Technology, Communications',
-  'Social Sciences and History',
-  'Social Welfare',
-  'Sports and Recreation',
-  'Taxation',
-  'Transportation and Public Works',
-  'Water Resources Development'
+  'Agriculture and Food', 'Animals', 'Armed Forces and National Security',
+  'Arts, Culture, Religion', 'Civil Rights and Liberties, Minority Issues',
+  'Commerce', 'Congress', 'Crime and Law Enforcement',
+  'Economics and Public Finance', 'Education', 'Emergency Management',
+  'Energy', 'Environmental Protection', 'Families',
+  'Finance and Financial Sector', 'Foreign Trade and International Finance',
+  'Government Operations and Politics', 'Health',
+  'Housing and Community Development', 'Immigration', 'International Affairs',
+  'Labor and Employment', 'Law', 'Native Americans', 'Private Legislation',
+  'Public Lands and Natural Resources', 'Science, Technology, Communications',
+  'Social Sciences and History', 'Social Welfare', 'Sports and Recreation',
+  'Taxation', 'Transportation and Public Works', 'Water Resources Development',
 ];
 
-// Map of state abbreviations to full names
-const STATE_NAMES: { [key: string]: string } = {
-  'AL': 'Alabama', 'AK': 'Alaska', 'AZ': 'Arizona', 'AR': 'Arkansas',
-  'CA': 'California', 'CO': 'Colorado', 'CT': 'Connecticut', 'DE': 'Delaware',
-  'FL': 'Florida', 'GA': 'Georgia', 'HI': 'Hawaii', 'ID': 'Idaho',
-  'IL': 'Illinois', 'IN': 'Indiana', 'IA': 'Iowa', 'KS': 'Kansas',
-  'KY': 'Kentucky', 'LA': 'Louisiana', 'ME': 'Maine', 'MD': 'Maryland',
-  'MA': 'Massachusetts', 'MI': 'Michigan', 'MN': 'Minnesota', 'MS': 'Mississippi',
-  'MO': 'Missouri', 'MT': 'Montana', 'NE': 'Nebraska', 'NV': 'Nevada',
-  'NH': 'New Hampshire', 'NJ': 'New Jersey', 'NM': 'New Mexico', 'NY': 'New York',
-  'NC': 'North Carolina', 'ND': 'North Dakota', 'OH': 'Ohio', 'OK': 'Oklahoma',
-  'OR': 'Oregon', 'PA': 'Pennsylvania', 'RI': 'Rhode Island', 'SC': 'South Carolina',
-  'SD': 'South Dakota', 'TN': 'Tennessee', 'TX': 'Texas', 'UT': 'Utah',
-  'VT': 'Vermont', 'VA': 'Virginia', 'WA': 'Washington', 'WV': 'West Virginia',
-  'WI': 'Wisconsin', 'WY': 'Wyoming', 'DC': 'District of Columbia'
+const STATE_NAMES: Record<string, string> = {
+  AL: 'Alabama', AK: 'Alaska', AZ: 'Arizona', AR: 'Arkansas',
+  CA: 'California', CO: 'Colorado', CT: 'Connecticut', DE: 'Delaware',
+  FL: 'Florida', GA: 'Georgia', HI: 'Hawaii', ID: 'Idaho',
+  IL: 'Illinois', IN: 'Indiana', IA: 'Iowa', KS: 'Kansas',
+  KY: 'Kentucky', LA: 'Louisiana', ME: 'Maine', MD: 'Maryland',
+  MA: 'Massachusetts', MI: 'Michigan', MN: 'Minnesota', MS: 'Mississippi',
+  MO: 'Missouri', MT: 'Montana', NE: 'Nebraska', NV: 'Nevada',
+  NH: 'New Hampshire', NJ: 'New Jersey', NM: 'New Mexico', NY: 'New York',
+  NC: 'North Carolina', ND: 'North Dakota', OH: 'Ohio', OK: 'Oklahoma',
+  OR: 'Oregon', PA: 'Pennsylvania', RI: 'Rhode Island', SC: 'South Carolina',
+  SD: 'South Dakota', TN: 'Tennessee', TX: 'Texas', UT: 'Utah',
+  VT: 'Vermont', VA: 'Virginia', WA: 'Washington', WV: 'West Virginia',
+  WI: 'Wisconsin', WY: 'Wyoming', DC: 'District of Columbia',
 };
 
-// Map of bill types to their full names
-const BILL_TYPE_NAMES: { [key: string]: string } = {
-  'hr': 'House Bill',
-  'hres': 'House Resolution',
-  'hjres': 'House Joint Resolution',
-  'hconres': 'House Concurrent Resolution',
-  's': 'Senate Bill',
-  'sres': 'Senate Resolution',
-  'sjres': 'Senate Joint Resolution',
-  'sconres': 'Senate Concurrent Resolution'
+const BILL_TYPE_NAMES: Record<string, string> = {
+  hr: 'House Bill',
+  hres: 'House Resolution',
+  hjres: 'House Joint Resolution',
+  hconres: 'House Concurrent Resolution',
+  s: 'Senate Bill',
+  sres: 'Senate Resolution',
+  sjres: 'Senate Joint Resolution',
+  sconres: 'Senate Concurrent Resolution',
 };
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All statuses' },
+  { value: '20',  label: 'Introduced' },
+  { value: '40',  label: 'In committee' },
+  { value: '60',  label: 'Passed one chamber' },
+  { value: '80',  label: 'Passed both chambers' },
+  { value: '90',  label: 'To President' },
+  { value: '95',  label: 'Signed by President' },
+  { value: '100', label: 'Became law' },
+];
+
+const DATE_OPTIONS = [
+  { value: 'all', label: 'All time' },
+  { value: 'week', label: 'Last week' },
+  { value: 'month', label: 'Last month' },
+  { value: '3months', label: 'Last 3 months' },
+  { value: '6months', label: 'Last 6 months' },
+  { value: 'year', label: 'Last year' },
+];
 
 interface BillsFilterProps {
   statusFilter: string;
@@ -96,35 +87,50 @@ interface BillsFilterProps {
   billTypeFilter: string;
   billNumberFilter: string;
   congressFilter: string;
-  onStatusChange: (value: string) => void;
-  onIntroducedDateChange: (value: string) => void;
-  onLastActionDateChange: (value: string) => void;
-  onSponsorChange: (value: string) => void;
-  onTitleChange: (value: string) => void;
-  onStateChange: (value: string) => void;
-  onPolicyAreaChange: (value: string) => void;
-  onBillTypeChange: (value: string) => void;
-  onBillNumberChange: (value: string) => void;
-  onCongressChange: (value: string) => void;
+  onStatusChange: (v: string) => void;
+  onIntroducedDateChange: (v: string) => void;
+  onLastActionDateChange: (v: string) => void;
+  onSponsorChange: (v: string) => void;
+  onTitleChange: (v: string) => void;
+  onStateChange: (v: string) => void;
+  onPolicyAreaChange: (v: string) => void;
+  onBillTypeChange: (v: string) => void;
+  onBillNumberChange: (v: string) => void;
+  onCongressChange: (v: string) => void;
   onClearAllFilters: () => void;
   isMobile: boolean;
 }
 
-interface StatusOption {
-  value: string;
+function FilterField({
+  label,
+  active,
+  children,
+}: {
   label: string;
+  active?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+        {active && <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent" />}
+      </label>
+      {children}
+    </div>
+  );
 }
 
-const statusOptions: StatusOption[] = [
-  { value: 'all', label: 'All Statuses' },
-  { value: '20', label: 'Introduced' },
-  { value: '40', label: 'In Committee' },
-  { value: '60', label: 'Passed One Chamber' },
-  { value: '80', label: 'Passed Both Chambers' },
-  { value: '90', label: 'To President' },
-  { value: '95', label: 'Signed by President' },
-  { value: '100', label: 'Became Law' },
-];
+function FilterGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-3">
+      <p className="font-serif text-base font-semibold tracking-tight border-b border-border pb-1.5">
+        {title}
+      </p>
+      <div className="space-y-3">{children}</div>
+    </div>
+  );
+}
 
 function BillsFilter({
   statusFilter,
@@ -162,322 +168,203 @@ function BillsFilter({
   useEffect(() => {
     const fetchCongressNumbers = async () => {
       try {
-        console.log('Fetching congress numbers...');
         const numbers = await billsService.getAvailableCongressNumbers();
-        console.log('Received congress numbers:', numbers);
         setAvailableCongressNumbers(numbers);
-        console.log('Set congress numbers in state:', numbers);
-      } catch (error) {
-        console.error('Error fetching congress numbers:', error);
+      } catch (e) {
+        console.error('Error fetching congress numbers:', e);
       }
     };
-
     fetchCongressNumbers();
   }, []);
 
-  // Helper function to check if a filter is active
-  const isFilterActive = (filterValue: string | null | undefined, defaultValue: string) => {
-    if (filterValue === null || filterValue === undefined) return false;
-    return filterValue !== defaultValue && filterValue !== '';
+  const isActive = (v: string | null | undefined, def: string) => {
+    if (v === null || v === undefined) return false;
+    return v !== def && v !== '';
   };
 
-  return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <h2 className="font-semibold">{isMobile ? 'Filter Bills' : 'Filters'}</h2>
-        <Button
-          onClick={onClearAllFilters}
-          variant="ghost"
-          size="sm"
-          className={cn(
-            "text-muted-foreground hover:text-foreground",
-            (isFilterActive(titleFilter, '') || 
-             isFilterActive(sponsorFilter, '') ||
-             isFilterActive(billNumberFilter, '') ||
-             isFilterActive(congressFilter, 'all') ||
-             isFilterActive(billTypeFilter, 'all') ||
-             isFilterActive(statusFilter, 'all') ||
-             isFilterActive(stateFilter, 'all') ||
-             isFilterActive(policyAreaFilter, 'all') ||
-             isFilterActive(introducedDateFilter, 'all') ||
-             isFilterActive(lastActionDateFilter, 'all')) && "text-foreground"
-          )}
-        >
-          Clear All
-        </Button>
-      </div>
+  const anyActive =
+    isActive(titleFilter, '') ||
+    isActive(sponsorFilter, '') ||
+    isActive(billNumberFilter, '') ||
+    isActive(congressFilter, 'all') ||
+    isActive(billTypeFilter, 'all') ||
+    isActive(statusFilter, 'all') ||
+    isActive(stateFilter, 'all') ||
+    isActive(policyAreaFilter, 'all') ||
+    isActive(introducedDateFilter, 'all') ||
+    isActive(lastActionDateFilter, 'all');
 
-      {/* Search Filters - Always immediate */}
-      <div className="space-y-4">
-        <div className="space-y-2">
-          <label htmlFor="titleFilter" className="text-sm font-medium flex items-center gap-2">
-            Bill Title
-            {isFilterActive(titleFilter, '') && (
-              <Circle className="h-2 w-2 fill-primary" />
+  const sheetMaxHeight = isMobile ? 'max-h-[40vh]' : '';
+
+  return (
+    <div className="space-y-7">
+      {/* Header — only on desktop. Mobile sheet has its own header. */}
+      {!isMobile && (
+        <div className="flex items-baseline justify-between border-b border-border pb-2">
+          <p className="font-serif text-lg font-semibold tracking-tight">Filter</p>
+          <button
+            onClick={onClearAllFilters}
+            className={cn(
+              'text-xs font-medium underline underline-offset-4 decoration-border transition-colors',
+              anyActive
+                ? 'text-foreground hover:decoration-foreground'
+                : 'text-muted-foreground/50 pointer-events-none'
             )}
-          </label>
+            aria-disabled={!anyActive}
+          >
+            Clear all
+          </button>
+        </div>
+      )}
+
+      <FilterGroup title="Search">
+        <FilterField label="Title" active={isActive(titleFilter, '')}>
           <Input
-            id="titleFilter"
             type="text"
-            placeholder="Search bill titles..."
+            placeholder="e.g. infrastructure"
             value={titleFilter}
             onChange={(e) => onTitleChange(e.target.value)}
-            className={cn(
-              "w-full",
-              isFilterActive(titleFilter, '') && "border-primary"
-            )}
           />
-        </div>
+        </FilterField>
 
-        <div className="space-y-2">
-          <label htmlFor="sponsorFilter" className="text-sm font-medium flex items-center gap-2">
-            Sponsor Name
-            {isFilterActive(sponsorFilter, '') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
+        <FilterField label="Sponsor" active={isActive(sponsorFilter, '')}>
           <Input
-            id="sponsorFilter"
             type="text"
-            placeholder="Search by sponsor..."
+            placeholder="Member's name"
             value={sponsorFilter}
             onChange={(e) => onSponsorChange(e.target.value)}
-            className={cn(
-              "w-full",
-              isFilterActive(sponsorFilter, '') && "border-primary"
-            )}
           />
-        </div>
+        </FilterField>
 
-        <div className="space-y-2">
-          <label htmlFor="billNumberFilter" className="text-sm font-medium flex items-center gap-2">
-            Bill Number
-            {isFilterActive(billNumberFilter, '') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
+        <FilterField label="Bill number" active={isActive(billNumberFilter, '')}>
           <Input
-            id="billNumberFilter"
             type="text"
             inputMode="numeric"
             pattern="[0-9]*"
-            placeholder="Enter bill number..."
+            placeholder="e.g. 1234"
             value={billNumberFilter}
             onChange={handleBillNumberChange}
-            className={cn(
-              "w-full",
-              isFilterActive(billNumberFilter, '') && "border-primary"
-            )}
           />
-        </div>
-      </div>
+        </FilterField>
+      </FilterGroup>
 
-      {/* Dropdown Filters */}
-      <div className="space-y-4">
-        {/* Congress Filter */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            Congress
-            {isFilterActive(congressFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select 
-            value={congressFilter} 
-            onValueChange={onCongressChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(congressFilter, 'all') && "border-primary"
-            )}>
+      <FilterGroup title="Identification">
+        <FilterField label="Congress" active={isActive(congressFilter, 'all')}>
+          <Select value={congressFilter} onValueChange={onCongressChange}>
+            <SelectTrigger>
               <SelectValue placeholder="All Congresses" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
+            <SelectContent className={sheetMaxHeight}>
               <SelectItem value="all">All Congresses</SelectItem>
-              {availableCongressNumbers.map((congress) => (
-                <SelectItem key={congress} value={congress.toString()}>
-                  {congress}th Congress
+              {availableCongressNumbers.map((c) => (
+                <SelectItem key={c} value={c.toString()}>
+                  {c}th Congress
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </FilterField>
 
-        {/* Bill Type Filter */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            Bill Type
-            {isFilterActive(billTypeFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select 
-            value={billTypeFilter} 
-            onValueChange={onBillTypeChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(billTypeFilter, 'all') && "border-primary"
-            )}>
-              <SelectValue placeholder="All Bill Types" />
+        <FilterField label="Bill type" active={isActive(billTypeFilter, 'all')}>
+          <Select value={billTypeFilter} onValueChange={onBillTypeChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="All bill types" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
-              <SelectItem value="all">All Bill Types</SelectItem>
-              {Object.entries(BILL_TYPE_NAMES).map(([type, fullName]) => (
-                <SelectItem key={type} value={type}>
-                  {fullName}
-                </SelectItem>
+            <SelectContent className={sheetMaxHeight}>
+              <SelectItem value="all">All bill types</SelectItem>
+              {Object.entries(BILL_TYPE_NAMES).map(([type, name]) => (
+                <SelectItem key={type} value={type}>{name}</SelectItem>
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </FilterField>
 
-        {/* Status Filter */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            Status
-            {isFilterActive(statusFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select
-            value={statusFilter}
-            onValueChange={onStatusChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(statusFilter, 'all') && "border-primary"
-            )}>
-              <SelectValue placeholder="All Statuses" />
+        <FilterField label="Status" active={isActive(statusFilter, 'all')}>
+          <Select value={statusFilter} onValueChange={onStatusChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="All statuses" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
-              {statusOptions.map(option => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
+            <SelectContent className={sheetMaxHeight}>
+              {STATUS_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </FilterField>
+      </FilterGroup>
 
-        {/* State Filter */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            State
-            {isFilterActive(stateFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select 
-            value={stateFilter} 
-            onValueChange={onStateChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(stateFilter, 'all') && "border-primary"
-            )}>
-              <SelectValue placeholder="All States" />
+      <FilterGroup title="Subject">
+        <FilterField label="Sponsor state" active={isActive(stateFilter, 'all')}>
+          <Select value={stateFilter} onValueChange={onStateChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="All states" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
-              <SelectItem value="all">All States</SelectItem>
+            <SelectContent className={sheetMaxHeight}>
+              <SelectItem value="all">All states</SelectItem>
               {Object.entries(STATE_NAMES).map(([abbr, name]) => (
-                <SelectItem key={abbr} value={abbr}>
-                  {name}
-                </SelectItem>
+                <SelectItem key={abbr} value={abbr}>{name}</SelectItem>
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </FilterField>
 
-        {/* Policy Area Filter */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            Category
-            {isFilterActive(policyAreaFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select 
-            value={policyAreaFilter} 
-            onValueChange={onPolicyAreaChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(policyAreaFilter, 'all') && "border-primary"
-            )}>
-              <SelectValue placeholder="All Categories" />
+        <FilterField label="Policy area" active={isActive(policyAreaFilter, 'all')}>
+          <Select value={policyAreaFilter} onValueChange={onPolicyAreaChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="All policy areas" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
-              <SelectItem value="all">All Categories</SelectItem>
+            <SelectContent className={sheetMaxHeight}>
+              <SelectItem value="all">All policy areas</SelectItem>
               {POLICY_AREAS.map((area) => (
-                <SelectItem key={area} value={area}>
-                  {area}
-                </SelectItem>
+                <SelectItem key={area} value={area}>{area}</SelectItem>
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </FilterField>
+      </FilterGroup>
 
-        {/* Date Filters */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            Introduced Date
-            {isFilterActive(introducedDateFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select 
-            value={introducedDateFilter} 
-            onValueChange={onIntroducedDateChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(introducedDateFilter, 'all') && "border-primary"
-            )}>
-              <SelectValue placeholder="All Dates" />
+      <FilterGroup title="Dates">
+        <FilterField label="Introduced" active={isActive(introducedDateFilter, 'all')}>
+          <Select value={introducedDateFilter} onValueChange={onIntroducedDateChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="All time" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
-              <SelectItem value="all">All Introduced Dates</SelectItem>
-              <SelectItem value="week">Last Week</SelectItem>
-              <SelectItem value="month">Last Month</SelectItem>
-              <SelectItem value="3months">Last 3 Months</SelectItem>
-              <SelectItem value="6months">Last 6 Months</SelectItem>
-              <SelectItem value="year">Last Year</SelectItem>
+            <SelectContent className={sheetMaxHeight}>
+              {DATE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
-        </div>
+        </FilterField>
 
-        <div className="space-y-2">
-          <label className="text-sm font-medium flex items-center gap-2">
-            Last Action Date
-            {isFilterActive(lastActionDateFilter, 'all') && (
-              <Circle className="h-2 w-2 fill-primary" />
-            )}
-          </label>
-          <Select 
-            value={lastActionDateFilter} 
-            onValueChange={onLastActionDateChange}
-          >
-            <SelectTrigger className={cn(
-              "w-full",
-              isFilterActive(lastActionDateFilter, 'all') && "border-primary"
-            )}>
-              <SelectValue placeholder="All Dates" />
+        <FilterField label="Last action" active={isActive(lastActionDateFilter, 'all')}>
+          <Select value={lastActionDateFilter} onValueChange={onLastActionDateChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="All time" />
             </SelectTrigger>
-            <SelectContent className={isMobile ? "max-h-[40vh]" : ""}>
-              <SelectItem value="all">All Action Dates</SelectItem>
-              <SelectItem value="week">Last Week</SelectItem>
-              <SelectItem value="month">Last Month</SelectItem>
-              <SelectItem value="3months">Last 3 Months</SelectItem>
-              <SelectItem value="6months">Last 6 Months</SelectItem>
-              <SelectItem value="year">Last Year</SelectItem>
+            <SelectContent className={sheetMaxHeight}>
+              {DATE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
-        </div>
-      </div>
+        </FilterField>
+      </FilterGroup>
+
+      {isMobile && (
+        <button
+          onClick={onClearAllFilters}
+          className={cn(
+            'text-sm font-medium underline underline-offset-4 decoration-border',
+            anyActive ? 'text-foreground' : 'text-muted-foreground/50 pointer-events-none'
+          )}
+          aria-disabled={!anyActive}
+        >
+          Clear all filters
+        </button>
+      )}
     </div>
   );
 }
 
-export default dynamic(() => Promise.resolve(BillsFilter), { ssr: false }); 
+export default dynamic(() => Promise.resolve(BillsFilter), { ssr: false });

--- a/components/bills/sync-status.tsx
+++ b/components/bills/sync-status.tsx
@@ -25,13 +25,12 @@ export default function SyncStatus() {
 
   if (!syncStatus?.completedAt) return null;
 
-  const timeAgo = formatDistanceToNow(new Date(syncStatus.completedAt), {
-    addSuffix: true,
-  });
+  const timeAgo = formatDistanceToNow(new Date(syncStatus.completedAt), { addSuffix: true });
 
   return (
-    <p className="text-xs text-muted-foreground/70">
-      Data updated {timeAgo}
-    </p>
+    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span className="h-1.5 w-1.5 rounded-full bg-status-law" aria-hidden="true" />
+      Updated {timeAgo}
+    </span>
   );
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,34 +3,66 @@ import { Github } from 'lucide-react';
 import Link from 'next/link';
 
 export function Footer() {
+  const year = new Date().getFullYear();
+
   return (
-    <footer className="border-t bg-background">
-      <div className="container mx-auto px-4">
-        <div className="flex h-24 flex-col items-center justify-between gap-4 md:flex-row md:gap-0">
-          <div className="flex items-center gap-2">
-            <p className="text-sm text-muted-foreground">
-              Data directly from Congress.gov.{' '}
-              <Link
-                href="/about"
-                className="font-medium underline underline-offset-4"
-              >
-                About this project
-              </Link>
+    <footer className="border-t border-border bg-background">
+      <div className="container-editorial py-10">
+        <div className="grid gap-8 md:grid-cols-4">
+          <div className="md:col-span-2 space-y-3">
+            <p className="font-serif text-xl font-semibold tracking-tight">
+              Bills<span className="text-accent">.</span>Congress
+            </p>
+            <p className="text-sm text-muted-foreground max-w-md leading-relaxed">
+              An independent record of legislation in the United States Congress.
+              Sourced directly from the public Congress.gov API. Not affiliated
+              with the U.S. government.
             </p>
           </div>
-          <div className="flex items-center gap-4">
-            <Link
-              href="https://github.com/shreyashguptas/billsincongress"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <Github className="h-5 w-5" />
-              <span className="sr-only">GitHub repository</span>
-            </Link>
-            <div className="h-4 w-[1px] bg-border" />
-            <ModeToggle />
+
+          <div>
+            <p className="label-eyebrow mb-3">Browse</p>
+            <ul className="space-y-2 text-sm">
+              <li><Link href="/" className="text-muted-foreground hover:text-foreground">Home</Link></li>
+              <li><Link href="/bills" className="text-muted-foreground hover:text-foreground">All bills</Link></li>
+              <li><Link href="/learn" className="text-muted-foreground hover:text-foreground">How Congress works</Link></li>
+              <li><Link href="/about" className="text-muted-foreground hover:text-foreground">About</Link></li>
+            </ul>
           </div>
+
+          <div>
+            <p className="label-eyebrow mb-3">Project</p>
+            <ul className="space-y-2 text-sm">
+              <li>
+                <a
+                  href="https://github.com/shreyashguptas/billsincongress"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
+                >
+                  <Github className="h-3.5 w-3.5" />
+                  Source on GitHub
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://api.congress.gov"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  Data: Congress.gov
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-10 flex flex-col-reverse gap-4 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground tabular">
+            © {year} Bills.Congress · Public-domain government data
+          </p>
+          <ModeToggle />
         </div>
       </div>
     </footer>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -5,67 +5,120 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
-import { Menu } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import { routes } from '@/lib/constants/routes';
 
 export function Navigation() {
   const [open, setOpen] = React.useState(false);
   const pathname = usePathname();
 
+  const today = new Date().toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-gradient-to-r from-[#002868] via-white to-[#BF0A30]">
-      <div className="container flex h-14 sm:h-16 items-center px-4">
-        <Sheet open={open} onOpenChange={setOpen}>
-          <SheetTrigger asChild>
-            <Button variant="ghost" className="mr-2 px-0 text-white md:hidden">
-              <Menu className="h-5 w-5 sm:h-6 sm:w-6" />
-              <span className="sr-only">Toggle menu</span>
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="w-[80%] max-w-sm pr-0">
-            <ScrollArea className="my-4 h-[calc(100vh-8rem)] pb-10">
-              <div className="flex flex-col space-y-2">
-                {routes.map((route) => (
-                  <Link
-                    key={route.href}
-                    href={route.href}
-                    className={cn(
-                      'px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground',
-                      pathname === route.href && 'bg-accent'
-                    )}
-                    onClick={() => setOpen(false)}
-                  >
-                    {route.label}
-                  </Link>
-                ))}
+    <header className="sticky top-0 z-40 w-full border-b border-border bg-background/85 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+      {/* Eyebrow strip — date + tagline (newspaper convention) */}
+      <div className="hidden md:block border-b border-border/60">
+        <div className="container-editorial flex h-7 items-center justify-between text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+          <span>{today}</span>
+          <span className="font-medium">An independent record of the U.S. Congress</span>
+        </div>
+      </div>
+
+      <div className="container-editorial flex h-14 sm:h-16 items-center justify-between gap-4">
+        {/* Mobile menu */}
+        <div className="flex md:hidden">
+          <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="-ml-2"
+                aria-label="Open menu"
+              >
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[88%] max-w-sm border-r border-border bg-background p-0">
+              <div className="flex items-center justify-between border-b border-border px-5 py-4">
+                <span className="font-serif text-lg font-semibold tracking-tight">
+                  Bills in Congress
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setOpen(false)}
+                  aria-label="Close menu"
+                >
+                  <X className="h-5 w-5" />
+                </Button>
               </div>
-            </ScrollArea>
-          </SheetContent>
-        </Sheet>
-        <div className="mr-4 hidden md:flex">
-          <Link href="/" className="mr-6 flex items-center space-x-2">
-            <span className="hidden font-bold lg:inline-block">
-              Congressional Bill Tracker
-            </span>
-            <span className="font-bold lg:hidden">Bill Tracker</span>
-          </Link>
-          <nav className="flex items-center space-x-4 lg:space-x-6 text-sm font-medium">
-            {routes.map((route) => (
+              <nav className="flex flex-col px-2 py-4">
+                {routes.map((route) => {
+                  const active = pathname === route.href;
+                  return (
+                    <Link
+                      key={route.href}
+                      href={route.href}
+                      onClick={() => setOpen(false)}
+                      className={cn(
+                        'flex items-center justify-between rounded-sm px-3 py-3 text-base font-sans border-l-2 border-transparent',
+                        active
+                          ? 'border-l-accent text-foreground font-medium'
+                          : 'text-muted-foreground hover:text-foreground hover:bg-secondary'
+                      )}
+                    >
+                      {route.label}
+                    </Link>
+                  );
+                })}
+              </nav>
+            </SheetContent>
+          </Sheet>
+        </div>
+
+        {/* Masthead title */}
+        <Link
+          href="/"
+          className="flex items-baseline gap-2 group"
+          aria-label="Bills in Congress — Home"
+        >
+          <span className="font-serif text-xl sm:text-2xl font-semibold tracking-tight text-foreground leading-none">
+            Bills<span className="text-accent">.</span>Congress
+          </span>
+          <span className="hidden lg:inline label-eyebrow">
+            Tracker
+          </span>
+        </Link>
+
+        {/* Desktop nav */}
+        <nav className="hidden md:flex items-center gap-1 text-sm">
+          {routes.map((route) => {
+            const active = pathname === route.href;
+            return (
               <Link
                 key={route.href}
                 href={route.href}
                 className={cn(
-                  'transition-colors hover:text-foreground/80',
-                  pathname === route.href ? 'text-foreground' : 'text-foreground/60'
+                  'relative px-3 py-2 font-medium transition-colors',
+                  active
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
                 )}
               >
                 {route.label}
+                {active && (
+                  <span className="absolute inset-x-3 -bottom-px h-px bg-foreground" />
+                )}
               </Link>
-            ))}
-          </nav>
-        </div>
+            );
+          })}
+        </nav>
       </div>
     </header>
   );

--- a/components/theme/mode-toggle.tsx
+++ b/components/theme/mode-toggle.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Moon, Sun, Monitor } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 export function ModeToggle() {
   const { setTheme, theme } = useTheme();
@@ -13,32 +13,39 @@ export function ModeToggle() {
     setMounted(true);
   }, []);
 
-  if (!mounted) {
-    return (
-      <Button variant="ghost" size="icon" className="h-9 w-9 relative">
-        <span className="h-4 w-4" />
-        <span className="sr-only">Loading theme toggle</span>
-      </Button>
-    );
-  }
-
-  const cycleTheme = () => {
-    if (theme === 'light') setTheme('dark');
-    else if (theme === 'dark') setTheme('system');
-    else setTheme('light');
-  };
+  const options: Array<{ value: 'light' | 'dark' | 'system'; icon: React.ReactNode; label: string }> = [
+    { value: 'light', icon: <Sun className="h-3.5 w-3.5" />, label: 'Light' },
+    { value: 'dark', icon: <Moon className="h-3.5 w-3.5" />, label: 'Dark' },
+    { value: 'system', icon: <Monitor className="h-3.5 w-3.5" />, label: 'System' },
+  ];
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={cycleTheme}
-      className="h-9 w-9 relative"
+    <div
+      role="radiogroup"
+      aria-label="Color theme"
+      className="inline-flex items-center rounded-sm border border-border bg-background p-0.5"
     >
-      {theme === 'light' && <Sun className="h-4 w-4" />}
-      {theme === 'dark' && <Moon className="h-4 w-4" />}
-      {theme === 'system' && <Monitor className="h-4 w-4" />}
-      <span className="sr-only">Toggle theme</span>
-    </Button>
+      {options.map((opt) => {
+        const active = mounted && theme === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={opt.label}
+            onClick={() => setTheme(opt.value)}
+            className={cn(
+              'inline-flex h-7 w-7 items-center justify-center rounded-sm transition-colors',
+              active
+                ? 'bg-foreground text-background'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {opt.icon}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,21 +4,24 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-sm px-2 py-0.5 font-sans text-[11px] font-medium uppercase tracking-[0.08em] transition-colors',
   {
     variants: {
       variant: {
         default:
-          'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+          'bg-foreground text-background',
         secondary:
-          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        destructive:
-          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-        outline: 'text-foreground',
+          'bg-secondary text-secondary-foreground',
+        outline:
+          'border border-border text-foreground bg-transparent',
+        accent:
+          'bg-accent text-accent-foreground',
+        muted:
+          'bg-transparent text-muted-foreground border border-border/70',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'outline',
     },
   }
 );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -7,25 +7,30 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm font-sans text-sm font-medium transition-all ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 select-none',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default:
+          'bg-foreground text-background hover:bg-foreground/85 active:bg-foreground/95',
+        accent:
+          'bg-accent text-accent-foreground hover:bg-accent/90 active:bg-accent',
+        outline:
+          'border border-border bg-transparent text-foreground hover:bg-secondary',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/70',
+        ghost:
+          'text-foreground hover:bg-secondary',
+        link:
+          'text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground p-0 h-auto rounded-none',
         destructive:
           'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        sm: 'h-8 px-3 text-xs',
+        default: 'h-10 px-4',
+        lg: 'h-11 px-6 text-[15px]',
+        icon: 'h-9 w-9',
       },
     },
     defaultVariants: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border bg-card text-card-foreground shadow-sm',
+      'rounded-sm border border-border bg-card text-card-foreground',
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-col space-y-1.5 p-6', className)}
+    className={cn('flex flex-col space-y-1.5 p-5', className)}
     {...props}
   />
 ));
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      'text-2xl font-semibold leading-none tracking-tight',
+      'font-serif text-xl font-semibold leading-tight tracking-tight',
       className
     )}
     {...props}
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-sm text-muted-foreground leading-relaxed', className)}
     {...props}
   />
 ));
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  <div ref={ref} className={cn('p-5 pt-0', className)} {...props} />
 ));
 CardContent.displayName = 'CardContent';
 
@@ -70,7 +70,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex items-center p-6 pt-0', className)}
+    className={cn('flex items-center p-5 pt-0', className)}
     {...props}
   />
 ));

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -11,7 +11,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-sm border border-border bg-background px-3 py-2 font-sans text-sm text-foreground transition-colors',
+          'placeholder:text-muted-foreground/70',
+          'file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground',
+          'focus-visible:outline-none focus-visible:border-foreground focus-visible:ring-1 focus-visible:ring-foreground/10',
+          'disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -11,13 +11,13 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+      'relative h-1.5 w-full overflow-hidden rounded-none bg-secondary',
       className
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full flex-1 bg-foreground transition-transform duration-500 ease-out"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-sm border border-border bg-background px-3 py-2 font-sans text-sm text-foreground transition-colors placeholder:text-muted-foreground/70 focus:outline-none focus:border-foreground focus:ring-1 focus:ring-foreground/10 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-sm border border-border bg-popover text-popover-foreground shadow-sm',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 font-sans text-sm text-foreground outline-none focus:bg-secondary data-[state=checked]:font-medium data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,143 +1,96 @@
 /** @type {import('tailwindcss').Config} */
 /* eslint-disable max-len */
-const colors = require('tailwindcss/colors');
 module.exports = {
   content: [
-    "./app/**/*.{js,ts,jsx,tsx}",
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
+    './app/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
   ],
   darkMode: 'class',
   theme: {
-    transparent: "transparent",
-    current: "currentColor",
+    container: {
+      center: true,
+      padding: {
+        DEFAULT: '1rem',
+        sm: '1.5rem',
+        lg: '2rem',
+      },
+      screens: {
+        '2xl': '1280px',
+      },
+    },
     extend: {
       fontFamily: {
-        serif: ['Playfair Display', 'Georgia', 'serif'],
-        sans: ['Source Sans 3', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
-        display: ['Playfair Display', 'Georgia', 'serif'],
-        body: ['Source Sans 3', 'system-ui', 'sans-serif'],
+        // Editorial display serif
+        serif: ['var(--font-serif)', 'Fraunces', 'Charter', 'Georgia', 'serif'],
+        display: ['var(--font-serif)', 'Fraunces', 'Charter', 'Georgia', 'serif'],
+        // UI / body sans
+        sans: ['var(--font-sans)', 'Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+        // Tabular monospace for bill numbers, vote tallies, etc.
+        mono: ['var(--font-mono)', 'JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+      },
+      fontSize: {
+        // Tightened editorial scale
+        'display-2xl': ['4.5rem', { lineHeight: '1.02', letterSpacing: '-0.025em' }],
+        'display-xl':  ['3.5rem', { lineHeight: '1.05', letterSpacing: '-0.022em' }],
+        'display-lg':  ['2.75rem', { lineHeight: '1.08', letterSpacing: '-0.02em' }],
+        'display-md':  ['2.125rem', { lineHeight: '1.15', letterSpacing: '-0.018em' }],
+        'display-sm':  ['1.625rem', { lineHeight: '1.2', letterSpacing: '-0.015em' }],
       },
       colors: {
-        congress: {
-          navy: {
-            50: '#e8ecf1',
-            100: '#d1d9e3',
-            200: '#a3b3c7',
-            300: '#758dab',
-            400: '#47678f',
-            500: '#1a4173',
-            600: '#15345c',
-            700: '#102746',
-            800: '#0b192f',
-            900: '#060c18',
-            950: '#03060c',
-          },
-          gold: {
-            50: '#fdf8eb',
-            100: '#faeecd',
-            200: '#f5dd9b',
-            300: '#f0cc69',
-            400: '#ebbb37',
-            500: '#c9a227',
-            600: '#a6821f',
-            700: '#836217',
-            800: '#60410f',
-            900: '#3d2107',
-          },
-          crimson: {
-            50: '#fce8ea',
-            100: '#f8d1d5',
-            200: '#f1a3ab',
-            300: '#e97581',
-            400: '#e24757',
-            500: '#9b1b30',
-            600: '#7d1626',
-            700: '#5f111c',
-            800: '#230709',
-            950: '#050200',
-          },
-        },
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
         },
         popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        // Bill-stage status palette — used in dashboard and badges
+        status: {
+          introduced: 'hsl(var(--status-introduced))',
+          committee: 'hsl(var(--status-committee))',
+          'passed-one': 'hsl(var(--status-passed-one))',
+          'passed-both': 'hsl(var(--status-passed-both))',
+          president: 'hsl(var(--status-president))',
+          signed: 'hsl(var(--status-signed))',
+          law: 'hsl(var(--status-law))',
         },
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-      },
-      boxShadow: {
-        'elegant': '0 4px 20px -2px rgba(0, 0, 0, 0.15)',
-        'elegant-lg': '0 10px 40px -4px rgba(0, 0, 0, 0.2)',
-        'card': '0 2px 8px -1px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-        'card-hover': '0 8px 24px -2px rgba(0, 0, 0, 0.15), 0 4px 8px -2px rgba(0, 0, 0, 0.1)',
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 1px)',
+        sm: 'calc(var(--radius) - 2px)',
       },
       animation: {
-        'slide-up': 'slide-up 0.5s ease-out forwards',
-        'fade-in': 'fade-in 0.3s ease-out forwards',
-        'scale-in': 'scale-in 0.3s ease-out forwards',
+        'fade-in': 'fade-in 0.4s ease-out forwards',
       },
     },
   },
-  safelist: [
-    {
-      pattern:
-        /^(bg-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
-      variants: ["hover", "ui-selected"],
-    },
-    {
-      pattern:
-        /^(text-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
-      variants: ["hover", "ui-selected"],
-    },
-    {
-      pattern:
-        /^(border-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
-      variants: ["hover", "ui-selected"],
-    },
-    {
-      pattern:
-        /^(ring-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
-    },
-    {
-      pattern:
-        /^(stroke-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
-    },
-    {
-      pattern:
-        /^(fill-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
-    },
-  ],
   plugins: [require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
Replace the prior look (US-flag gradient nav, dark navy dashboard, dense visualisations) with a single editorial-newspaper system — warm paper background, ink foreground, one masthead-red accent, serif (Fraunces) for display, sans (Inter) for UI, mono (JetBrains Mono) for tabular data. Reuse the same primitives everywhere.

Foundation
- Replace globals.css with HSL design tokens for both light/dark.
- Rewrite tailwind.config.ts: new font stacks via next/font CSS variables, editorial type scale, status palette, tighter radius.
- Switch root layout to next/font with Fraunces + Inter + JetBrains Mono and add a skip link.
- Restore zoomable viewport (was disabled — accessibility).

Component library
- Button: monochrome default + accent + outline + ghost; smaller radius; no decorative shadows.
- Card / Input / Select / Progress / Badge: hairline borders, square corners, no glow, focus uses foreground colour.
- ModeToggle: segmented light/dark/system control.

Layout
- Navigation: editorial masthead with date eyebrow, Bills.Congress wordmark, underline indicator for active route.
- Footer: four-column site map with colophon and theme picker.

Pages
- Home / dashboard: editorial front page in the global layout. Hero + four key metrics + Tufte-style stacked status bar + policy-area list + sponsor table + quiet historical chart. Drops decorative donuts, gradients, stage delays, duplicate header/footer.
- Bills index: sticky filter sidebar, grouped filter sections, cleaner result grid, accessible mobile sheet.
- Bill detail: article treatment with sponsor sidebar, horizontal pipeline progress, dropped-cap summary, restyled chat.
- About: colophon + numbered process steps + facts sidebar.
- Learn: single-file editorial primer in four sections (replaces the framer-motion-heavy multi-section page).