### PR TITLE
diagnostic: add aggregateBackfill:status query

### DIFF
--- a/convex/aggregateBackfill.ts
+++ b/convex/aggregateBackfill.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
-import { internalAction, internalQuery } from "./_generated/server";
+import { internalAction, internalQuery, query } from "./_generated/server";
 import { internalMutation } from "./functions";
 import { billsByChamber, billsByStage } from "./aggregates";
 
@@ -157,5 +157,65 @@ export const clearAggregates = internalMutation({
   handler: async (ctx) => {
     await billsByChamber.clearAll(ctx);
     await billsByStage.clearAll(ctx);
+  },
+});
+
+/**
+ * Diagnostic: return the current aggregate counts and a bills-table probe
+ * side-by-side for each interesting congress. Runs as a public query so it
+ * can be called from the CLI or curl without auth:
+ *
+ *     npx convex run --prod aggregateBackfill:status '{}'
+ *
+ *     # or via HTTP:
+ *     curl -sX POST https://industrious-llama-331.convex.cloud/api/query \
+ *       -H 'Content-Type: application/json' \
+ *       -d '{"path":"aggregateBackfill:status","args":{},"format":"json"}'
+ *
+ * Use this to tell whether the aggregate is empty, partially populated,
+ * or complete — compared to the actual bills table.
+ */
+export const status = query({
+  args: {},
+  handler: async (ctx) => {
+    const congresses = [117, 118, 119];
+    const out = [] as Array<{
+      congress: number;
+      aggregateTotal: number;
+      aggregateHouse: number;
+      aggregateSenate: number;
+      billsProbe1k: number;
+    }>;
+    for (const congress of congresses) {
+      const ns = { namespace: congress };
+      const [house, senate] = await billsByChamber.countBatch(ctx, [
+        {
+          ...ns,
+          bounds: {
+            lower: { key: "h", inclusive: true },
+            upper: { key: "i", inclusive: false },
+          },
+        },
+        {
+          ...ns,
+          bounds: {
+            lower: { key: "s", inclusive: true },
+            upper: { key: "t", inclusive: false },
+          },
+        },
+      ]);
+      const probe = await ctx.db
+        .query("bills")
+        .withIndex("by_congress", (q) => q.eq("congress", congress))
+        .take(1000);
+      out.push({
+        congress,
+        aggregateTotal: house + senate,
+        aggregateHouse: house,
+        aggregateSenate: senate,
+        billsProbe1k: probe.length,
+      });
+    }
+    return out;
   },
 });


### PR DESCRIPTION
## Why

The backfill is still stalled after the second run at batch=50 — 30 minutes of polling shows zero movement on 117/118 `congressStats`. We can't tell from the outside whether the aggregates are genuinely empty, partially populated (stopped at a round number like 10,000 from the first 500-batch attempt), or whether it's a completely different bug.

The new `aggregateBackfill:status` query returns aggregate totals side-by-side with a 1,000-bill probe of the actual bills table, so we can diagnose directly.

## Usage

After `npx convex deploy`:

```bash
npx convex run --prod aggregateBackfill:status '{}'
```

Expected output shape:

```json
[
  {"congress":117,"aggregateTotal":10000,"aggregateHouse":5418,"aggregateSenate":4582,"billsProbe1k":1000},
  {"congress":118,"aggregateTotal":10000,"aggregateHouse":5493,"aggregateSenate":4507,"billsProbe1k":1000},
  {"congress":119,"aggregateTotal":6158,"aggregateHouse":3972,"aggregateSenate":2186,"billsProbe1k":1000}
]
```

If `aggregateTotal` for 117/118 is exactly 10,000, that confirms the "stalled at 20×500 batches" theory. If it's 0 or some other low number, we look elsewhere.

## Test plan

- [x] `npx tsc -p convex/tsconfig.json` — passes
- [ ] After deploy, `status` query returns live aggregate numbers.

https://claude.ai/code/session_01YMhWaz9bzNCpcmn3y9VuyB