### PR TITLE
perf(homepage): server-render with cached Convex data + precompute ch…

### DIFF
--- a/app/bills/[id]/page.tsx
+++ b/app/bills/[id]/page.tsx
@@ -1,78 +1,91 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
+import { cacheLife, cacheTag } from 'next/cache';
 import BillDetails from '../../../components/bills/bill-details';
 import { billsService } from '@/lib/services/bills-service';
+import type { Bill } from '@/lib/types/bill';
 import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
-
-// Enable ISR with 1-hour revalidation
-export const revalidate = 3600;
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-// Generate metadata for the page
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+// Cache the per-bill fetch at the edge. 1-hour revalidate matches the
+// previous `export const revalidate = 3600` ISR window. The bill ID
+// argument forms the cache key automatically. Returns `null` on any
+// failure (missing Convex env, bill not found, network error) so the
+// caller can route to notFound() cleanly — throwing inside `'use cache'`
+// fails the prerender for placeholder routes.
+async function getCachedBill(id: string): Promise<Bill | null> {
+  'use cache';
+  cacheLife({ revalidate: 3600 });
+  cacheTag('bills', `bill-${id}`);
   try {
-    const { id } = await params;
-    const bill = await billsService.fetchBillById(id);
-    
-    return {
-      title: `${bill.bill_type_label} ${bill.bill_number} - ${bill.congress}th Congress`,
-      description: bill.title,
-    };
-  } catch (error: unknown) {
-    console.error('Error generating metadata:', error);
-    return {
-      title: 'Bill Not Found',
-    };
+    return await billsService.fetchBillById(id);
+  } catch (error) {
+    console.error(`getCachedBill(${id}) failed:`, error);
+    return null;
   }
 }
 
-// Pre-generate the most recent 100 bills at build time
+// Cache Components requires `generateStaticParams` to return at least one
+// entry so the build can validate the route. We try to fetch the most
+// recent 100 bills (matches the previous ISR pre-generation behavior); if
+// the build environment lacks Convex env or the fetch fails, we fall back
+// to a single placeholder route which renders a 404 at build time via
+// notFound() and resolves real bills on demand via getCachedBill.
 export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   try {
     const { data } = await billsService.fetchBills({
       page: 1,
       itemsPerPage: 100,
     });
-
-    return data.map((bill) => ({
-      id: bill.id,
-    }));
+    if (data.length > 0) {
+      return data.map((bill) => ({ id: bill.id }));
+    }
   } catch (error: unknown) {
     console.error('Error generating static params:', error);
-    return [];
   }
+  return [{ id: '__placeholder__' }];
+}
+
+// Generate metadata for the page
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const bill = await getCachedBill(id);
+
+  if (!bill) {
+    return { title: 'Bill Not Found' };
+  }
+
+  return {
+    title: `${bill.bill_type_label} ${bill.bill_number} - ${bill.congress}th Congress`,
+    description: bill.title,
+  };
 }
 
 export default async function BillPage({ params }: PageProps): Promise<ReactElement> {
-  try {
-    const { id } = await params;
-    const bill = await billsService.fetchBillById(id);
+  const { id } = await params;
+  const bill = await getCachedBill(id);
 
-    if (!bill) {
-      notFound();
-    }
-
-    return (
-      <Suspense
-        fallback={
-          <div className="container-editorial py-16">
-            <div className="space-y-3">
-              <div className="h-3 w-24 bg-secondary rounded-sm animate-pulse" />
-              <div className="h-10 w-2/3 bg-secondary rounded-sm animate-pulse" />
-              <div className="h-4 w-1/2 bg-secondary rounded-sm animate-pulse" />
-            </div>
-          </div>
-        }
-      >
-        <BillDetails bill={bill} />
-      </Suspense>
-    );
-  } catch (error: unknown) {
-    console.error('Error loading bill:', error);
+  if (!bill) {
     notFound();
   }
+
+  return (
+    <Suspense
+      fallback={
+        <div className="container-editorial py-16">
+          <div className="space-y-3">
+            <div className="h-3 w-24 bg-secondary rounded-sm animate-pulse" />
+            <div className="h-10 w-2/3 bg-secondary rounded-sm animate-pulse" />
+            <div className="h-4 w-1/2 bg-secondary rounded-sm animate-pulse" />
+          </div>
+        </div>
+      }
+    >
+      <BillDetails bill={bill} />
+    </Suspense>
+  );
 }

--- a/app/components/dashboard/DashboardClient.tsx
+++ b/app/components/dashboard/DashboardClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 import { api } from '../../../convex/_generated/api';
 import { useRouter } from 'next/navigation';
 import { useConvexEnabled } from '../../ConvexClientProvider';
@@ -9,16 +10,34 @@ import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
+// Shape of the SSR-loaded data passed through from app/page.tsx.
+// Each field mirrors the return type of its Convex query.
+export type InitialDashboardData = {
+  allCongress: FunctionReturnType<typeof api.bills.getAllCongressOverview>;
+  dashboard: FunctionReturnType<typeof api.bills.getCongressDashboard>;
+  house: FunctionReturnType<typeof api.bills.getChamberDeepBreakdown>;
+  senate: FunctionReturnType<typeof api.bills.getChamberDeepBreakdown>;
+};
+
 interface DashboardProps {
   initialCongress?: number;
+  initialData?: InitialDashboardData | null;
 }
 
-export default function Dashboard({ initialCongress = 119 }: DashboardProps) {
+export default function Dashboard({
+  initialCongress = 119,
+  initialData = null,
+}: DashboardProps) {
   const convexEnabled = useConvexEnabled();
   if (!convexEnabled) {
     return <ConvexNotConfigured />;
   }
-  return <DashboardInner initialCongress={initialCongress} />;
+  return (
+    <DashboardInner
+      initialCongress={initialCongress}
+      initialData={initialData}
+    />
+  );
 }
 
 function ConvexNotConfigured() {
@@ -44,23 +63,43 @@ function ConvexNotConfigured() {
   );
 }
 
-function DashboardInner({ initialCongress = 119 }: DashboardProps) {
+function DashboardInner({
+  initialCongress = 119,
+  initialData = null,
+}: DashboardProps) {
   const router = useRouter();
   const [selectedCongress, setSelectedCongress] = useState(initialCongress);
 
-  const allCongressData = useQuery(api.bills.getAllCongressOverview);
-  const congressDashboard = useQuery(api.bills.getCongressDashboard, {
-    congress: selectedCongress,
-  });
+  // While the user is on the SSR'd Congress, skip the live queries — the
+  // initial render has all the data inline. Subscribing only happens when
+  // the user clicks a different Congress button, which is rare on cold load.
+  const isInitial = selectedCongress === initialCongress;
 
-  const houseBreakdown = useQuery(api.bills.getChamberDeepBreakdown, {
-    congress: selectedCongress,
-    chamber: 'house',
-  });
-  const senateBreakdown = useQuery(api.bills.getChamberDeepBreakdown, {
-    congress: selectedCongress,
-    chamber: 'senate',
-  });
+  const liveAll = useQuery(api.bills.getAllCongressOverview);
+  const liveDashboard = useQuery(
+    api.bills.getCongressDashboard,
+    isInitial ? 'skip' : { congress: selectedCongress },
+  );
+  const liveHouse = useQuery(
+    api.bills.getChamberDeepBreakdown,
+    isInitial
+      ? 'skip'
+      : { congress: selectedCongress, chamber: 'house' as const },
+  );
+  const liveSenate = useQuery(
+    api.bills.getChamberDeepBreakdown,
+    isInitial
+      ? 'skip'
+      : { congress: selectedCongress, chamber: 'senate' as const },
+  );
+
+  // The historical chart spans every Congress, so it doesn't depend on
+  // selectedCongress — keep it always-live so it picks up new data, falling
+  // back to the SSR snapshot until the websocket replies.
+  const allCongressData = liveAll ?? initialData?.allCongress;
+  const congressDashboard = isInitial ? initialData?.dashboard : liveDashboard;
+  const houseBreakdown = isInitial ? initialData?.house : liveHouse;
+  const senateBreakdown = isInitial ? initialData?.senate : liveSenate;
 
   const congressNumbers =
     allCongressData?.filter((d) => d.totalCount > 0).map((d) => d.congress) || [];
@@ -78,11 +117,11 @@ function DashboardInner({ initialCongress = 119 }: DashboardProps) {
     router.push(`/bills?${params.toString()}`);
   };
 
-  if (allCongressData === undefined || congressDashboard === undefined) {
+  if (!allCongressData || !congressDashboard) {
     return <DashboardSkeleton />;
   }
 
-  if (!allCongressData || allCongressData.length === 0) {
+  if (allCongressData.length === 0) {
     return (
       <div className="container-editorial py-24 text-center text-muted-foreground">
         No data available.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,27 @@
-'use client';
+import { Suspense } from 'react';
+import { cacheLife, cacheTag } from 'next/cache';
+import { fetchQuery } from 'convex/nextjs';
+import { api } from '@/convex/_generated/api';
+import DashboardClient, {
+  type InitialDashboardData,
+} from './components/dashboard/DashboardClient';
 
-import dynamic from 'next/dynamic';
+// PPR pattern: the page itself is fully static (just a shell + Suspense
+// boundary). Dynamic searchParams are awaited inside the Suspense'd loader
+// so they don't block the static shell from flushing to the browser.
+export default function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ congress?: string }>;
+}) {
+  return (
+    <Suspense fallback={<HomeShell />}>
+      <DashboardServerLoader searchParams={searchParams} />
+    </Suspense>
+  );
+}
 
-const DashboardClient = dynamic(
-  () => import('./components/dashboard/DashboardClient'),
-  { ssr: false, loading: () => <LoadingState /> }
-);
-
-function LoadingState() {
+function HomeShell() {
   return (
     <div className="container-editorial py-16 sm:py-24">
       <div className="space-y-3">
@@ -19,6 +33,46 @@ function LoadingState() {
   );
 }
 
-export default function Home() {
-  return <DashboardClient />;
+async function DashboardServerLoader({
+  searchParams,
+}: {
+  searchParams: Promise<{ congress?: string }>;
+}) {
+  const params = await searchParams;
+  const congress = Number(params.congress) || 119;
+  const data = await loadDashboardData(congress);
+  return <DashboardClient initialCongress={congress} initialData={data} />;
+}
+
+// Cached at the edge — the function argument forms the cache key, so
+// `?congress=119` and `?congress=118` get separate entries automatically.
+// Bills sync once per day so a 10-minute revalidate window is generous;
+// 1-hour hard expiry keeps the cache from going arbitrarily stale.
+async function loadDashboardData(
+  congress: number,
+): Promise<InitialDashboardData | null> {
+  'use cache';
+  cacheLife({ stale: 60, revalidate: 600, expire: 3600 });
+  cacheTag('bills-dashboard', `bills-dashboard-${congress}`);
+
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) return null;
+
+  try {
+    const [allCongress, dashboard, house, senate] = await Promise.all([
+      fetchQuery(api.bills.getAllCongressOverview),
+      fetchQuery(api.bills.getCongressDashboard, { congress }),
+      fetchQuery(api.bills.getChamberDeepBreakdown, {
+        congress,
+        chamber: 'house',
+      }),
+      fetchQuery(api.bills.getChamberDeepBreakdown, {
+        congress,
+        chamber: 'senate',
+      }),
+    ]);
+    return { allCongress, dashboard, house, senate };
+  } catch (error) {
+    console.error('loadDashboardData failed:', error);
+    return null;
+  }
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,8 +1,14 @@
 import { ModeToggle } from '@/components/theme/mode-toggle';
+import { cacheLife } from 'next/cache';
 import { Github } from 'lucide-react';
 import Link from 'next/link';
 
-export function Footer() {
+// The copyright year is the only non-deterministic value here. Caching the
+// whole Footer for a week is fine — the year doesn't change between cache
+// refreshes, and the rest is fully static.
+export async function Footer() {
+  'use cache';
+  cacheLife('weeks');
   const year = new Date().getFullYear();
 
   return (

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -13,12 +13,20 @@ export function Navigation() {
   const [open, setOpen] = React.useState(false);
   const pathname = usePathname();
 
-  const today = new Date().toLocaleDateString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  // Compute the date after hydration. Cache Components disallows `new Date()`
+  // during prerender; this defers it to the client so the prerendered HTML
+  // doesn't lock in a stale date string.
+  const [today, setToday] = React.useState('');
+  React.useEffect(() => {
+    setToday(
+      new Date().toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    );
+  }, []);
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/85 backdrop-blur supports-[backdrop-filter]:bg-background/70">

--- a/convex/bills.ts
+++ b/convex/bills.ts
@@ -566,47 +566,17 @@ export const getAllCongressOverview = query({
   },
 });
 
-/* ─────────────────────────────────────────────────────────────────────────
- * Deep breakdowns — party / state / monthly cadence
- *
- * These power three new homepage visuals (party split, top states, monthly
- * introduction timeline). They read the bills table directly because the
- * precomputed aggregates don't carry party / state / introducedDate dimensions.
- *
- * IMPORTANT — Convex query functions are capped at ~16,384 document reads per
- * transaction. Several Congresses (117, 118) exceed that in total bills, so we
- * split the query by *chamber*: each chamber has at most ~13K bills even in
- * the largest Congress, comfortably under the cap. The client calls the query
- * twice (once per chamber) and merges the results in-memory.
- * ───────────────────────────────────────────────────────────────────────── */
-
-// All bill-type prefixes per chamber. Mirrors HOUSE_BILL_TYPES /
-// SENATE_BILL_TYPES in aggregates.ts but kept local to avoid cross-imports in
-// this file.
-const HOUSE_TYPES = ["hr", "hjres", "hconres", "hres"] as const;
-const SENATE_TYPES = ["s", "sjres", "sconres", "sres"] as const;
-
-// Normalise raw party letter codes (D / R / I / ID / blank) into one of four
-// display buckets so the UI doesn't have to worry about edge cases.
-function normaliseParty(raw: string | undefined): "D" | "R" | "I" | "U" {
-  if (!raw) return "U";
-  const v = raw.trim().toUpperCase();
-  if (v === "D") return "D";
-  if (v === "R") return "R";
-  if (v === "I" || v === "ID" || v === "IND") return "I";
-  return "U";
-}
-
 /**
- * Per-chamber deep breakdown for one Congress.
+ * Per-chamber deep breakdown for one Congress (party / state / monthly).
  *
- * Returns partisan / geographic / temporal aggregations for a single chamber,
- * computed from the raw bills table. The caller fires this once per chamber
- * and merges the two responses client-side.
+ * Reads a single precomputed row from `congressChamberBreakdowns` —
+ * populated by `recomputeCongressChamberBreakdown` after each sync and by
+ * the daily 4 AM stats cron. Replaces a previous implementation that
+ * scanned 6-7K bill documents per call, which dominated homepage cold-load
+ * latency.
  *
- * Why split by chamber: a single query can read up to ~16,384 documents;
- * Congress 118 alone has 19,314 bills across both chambers. Every chamber on
- * record stays under ~13K bills, so per-chamber queries always fit.
+ * Returns an empty-shape response if the precomputed row hasn't been
+ * built yet — the homepage tolerates zero counts.
  */
 export const getChamberDeepBreakdown = query({
   args: {
@@ -614,68 +584,43 @@ export const getChamberDeepBreakdown = query({
     chamber: v.union(v.literal("house"), v.literal("senate")),
   },
   handler: async (ctx, args) => {
-    const billTypes = args.chamber === "house" ? HOUSE_TYPES : SENATE_TYPES;
+    const row = await ctx.db
+      .query("congressChamberBreakdowns")
+      .withIndex("by_congress_and_chamber", (q) =>
+        q.eq("congress", args.congress).eq("chamber", args.chamber),
+      )
+      .unique();
 
-    // Fetch all bills for each bill type within this chamber+congress.
-    // `by_congress_and_type` is a compound index so each call is O(log n) + k.
-    const chunks: Doc<"bills">[][] = [];
-    for (const billType of billTypes) {
-      const chunk = await ctx.db
-        .query("bills")
-        .withIndex("by_congress_and_type", (q) =>
-          q.eq("congress", args.congress).eq("billType", billType),
-        )
-        .collect();
-      chunks.push(chunk);
-    }
-    const bills = chunks.flat();
-
-    // Aggregate in a single pass.
-    const partyCounts: Record<"D" | "R" | "I" | "U", number> = {
-      D: 0, R: 0, I: 0, U: 0,
-    };
-    const partyLawCounts: Record<"D" | "R" | "I" | "U", number> = {
-      D: 0, R: 0, I: 0, U: 0,
-    };
-    const stateCounts = new Map<string, number>();
-    const monthCounts = new Map<string, { total: number; law: number }>();
-
-    for (const bill of bills) {
-      const party = normaliseParty(bill.sponsorParty);
-      const isLaw = bill.progressStage === 100;
-
-      partyCounts[party] += 1;
-      if (isLaw) partyLawCounts[party] += 1;
-
-      // Only aggregate valid ASCII state codes — Convex object keys must be
-      // non-control ASCII, and we don't want "Unknown" polluting the top-states
-      // list on the homepage.
-      if (bill.sponsorState && /^[A-Z]{2,3}$/.test(bill.sponsorState)) {
-        stateCounts.set(
-          bill.sponsorState,
-          (stateCounts.get(bill.sponsorState) || 0) + 1,
-        );
-      }
-
-      // introducedDate is "YYYY-MM-DD"; bucket by month (YYYY-MM).
-      const month = (bill.introducedDate || "").slice(0, 7);
-      if (month) {
-        const entry = monthCounts.get(month) || { total: 0, law: 0 };
-        entry.total += 1;
-        if (isLaw) entry.law += 1;
-        monthCounts.set(month, entry);
-      }
+    if (!row) {
+      return {
+        chamber: args.chamber,
+        total: 0,
+        partyCounts: { D: 0, R: 0, I: 0, U: 0 } as Record<
+          "D" | "R" | "I" | "U",
+          number
+        >,
+        partyLawCounts: { D: 0, R: 0, I: 0, U: 0 } as Record<
+          "D" | "R" | "I" | "U",
+          number
+        >,
+        stateCounts: {} as Record<string, number>,
+        monthly: [] as Array<{
+          month: string;
+          count: number;
+          becameLaw: number;
+        }>,
+      };
     }
 
     return {
       chamber: args.chamber,
-      total: bills.length,
-      partyCounts,
-      partyLawCounts,
-      stateCounts: Object.fromEntries(stateCounts),
-      monthly: Array.from(monthCounts.entries())
-        .map(([month, v]) => ({ month, count: v.total, becameLaw: v.law }))
-        .sort((a, b) => a.month.localeCompare(b.month)),
+      total: row.total,
+      partyCounts: row.partyCounts,
+      partyLawCounts: row.partyLawCounts,
+      stateCounts: Object.fromEntries(
+        row.stateCounts.map((s) => [s.state, s.count]),
+      ),
+      monthly: row.monthly,
     };
   },
 });

--- a/convex/congressApi.ts
+++ b/convex/congressApi.ts
@@ -28,6 +28,10 @@ const BILL_TYPES = [
   "sres",
 ];
 
+// Lookup for resolving chamber from billType when scheduling per-chamber
+// breakdown recomputes after each bill type finishes syncing.
+const HOUSE_TYPES_SET = new Set(["hr", "hjres", "hconres", "hres"]);
+
 // Bill stage constants
 const BillStages = {
   INTRODUCED: 20,
@@ -572,6 +576,17 @@ export const syncBillBatch = internalAction({
       await ctx.runAction(internal.mutations.recomputeCongressSponsors, {
         congress: args.congress,
       });
+
+      // Refresh the per-chamber deep breakdown for the chamber this bill
+      // type belongs to. The other chamber will be recomputed when its own
+      // bill types finish; the daily 4 AM cron does a full sweep regardless.
+      const chamber: "house" | "senate" = HOUSE_TYPES_SET.has(args.billType)
+        ? "house"
+        : "senate";
+      await ctx.runAction(
+        internal.mutations.recomputeCongressChamberBreakdown,
+        { congress: args.congress, chamber },
+      );
     }
 
     return { processed: bills.length, hasMore, successCount, failCount };
@@ -1027,6 +1042,18 @@ export const recomputeAllStats = internalAction({
     // Recompute stats for each congress
     for (const congress of congressesToUpdate) {
       await ctx.runMutation(internal.mutations.recomputeCongressStats, { congress });
+    }
+
+    // Recompute the per-chamber deep breakdown (party / state / monthly).
+    // Each call paginates through ~6-7K bills, so we run them sequentially
+    // to stay polite to the database.
+    for (const congress of congressesToUpdate) {
+      for (const chamber of ["house", "senate"] as const) {
+        await ctx.runAction(
+          internal.mutations.recomputeCongressChamberBreakdown,
+          { congress, chamber },
+        );
+      }
     }
 
     console.log(`Recomputed stats for congresses: ${congressesToUpdate.join(", ")}`);

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -5,7 +5,13 @@ import {
 } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
-import { billsByChamber, billsByStage, BILL_STAGES } from "./aggregates";
+import {
+  billsByChamber,
+  billsByStage,
+  BILL_STAGES,
+  HOUSE_BILL_TYPES,
+  SENATE_BILL_TYPES,
+} from "./aggregates";
 
 /**
  * Upsert a bill record. If a bill with the same billId exists, update it.
@@ -545,6 +551,217 @@ export const recomputeCongressSponsors = internalAction({
       congress: args.congress,
       sponsors,
     });
+  },
+});
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Chamber deep breakdown precompute
+ *
+ * Mirrors the policy-areas / sponsors pattern: paginate the bills table to
+ * dodge the 16K-doc per-mutation read limit, aggregate party / state /
+ * monthly counts in an action, then write the result atomically.
+ *
+ * The homepage `getChamberDeepBreakdown` query reads the resulting row in
+ * O(1), replacing a 6-7K-doc scan that dominated cold-load latency.
+ * ───────────────────────────────────────────────────────────────────── */
+
+function normaliseParty(raw: string | undefined): "D" | "R" | "I" | "U" {
+  if (!raw) return "U";
+  const v = raw.trim().toUpperCase();
+  if (v === "D") return "D";
+  if (v === "R") return "R";
+  if (v === "I" || v === "ID" || v === "IND") return "I";
+  return "U";
+}
+
+/** Paginated fetch of bills for a single (congress, billType). */
+export const getChamberBillsPage = internalQuery({
+  args: {
+    congress: v.number(),
+    billType: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("bills")
+      .withIndex("by_congress_and_type", (q) =>
+        q.eq("congress", args.congress).eq("billType", args.billType),
+      )
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+  },
+});
+
+/** Atomic write of a (congress, chamber) breakdown row. */
+export const writeCongressChamberBreakdown = internalMutation({
+  args: {
+    congress: v.number(),
+    chamber: v.union(v.literal("house"), v.literal("senate")),
+    total: v.number(),
+    partyCounts: v.object({
+      D: v.number(),
+      R: v.number(),
+      I: v.number(),
+      U: v.number(),
+    }),
+    partyLawCounts: v.object({
+      D: v.number(),
+      R: v.number(),
+      I: v.number(),
+      U: v.number(),
+    }),
+    stateCounts: v.array(
+      v.object({ state: v.string(), count: v.number() }),
+    ),
+    monthly: v.array(
+      v.object({
+        month: v.string(),
+        count: v.number(),
+        becameLaw: v.number(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("congressChamberBreakdowns")
+      .withIndex("by_congress_and_chamber", (q) =>
+        q.eq("congress", args.congress).eq("chamber", args.chamber),
+      )
+      .unique();
+
+    const data = {
+      congress: args.congress,
+      chamber: args.chamber,
+      total: args.total,
+      partyCounts: args.partyCounts,
+      partyLawCounts: args.partyLawCounts,
+      stateCounts: args.stateCounts,
+      monthly: args.monthly,
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, data);
+    } else {
+      await ctx.db.insert("congressChamberBreakdowns", data);
+    }
+  },
+});
+
+type ChamberBillPageResult = {
+  page: Array<{
+    sponsorParty?: string;
+    sponsorState?: string;
+    progressStage?: number;
+    introducedDate: string;
+  }>;
+  isDone: boolean;
+  continueCursor: string;
+};
+
+/**
+ * Recompute the chamber breakdown for one (congress, chamber).
+ * Paginates through every bill type in the chamber so total bill count is
+ * never silently truncated. The aggregation runs in an action (no doc cap)
+ * and the write happens in one mutation.
+ */
+export const recomputeCongressChamberBreakdown = internalAction({
+  args: {
+    congress: v.number(),
+    chamber: v.union(v.literal("house"), v.literal("senate")),
+  },
+  handler: async (ctx, args) => {
+    const billTypes =
+      args.chamber === "house" ? HOUSE_BILL_TYPES : SENATE_BILL_TYPES;
+
+    const partyCounts: Record<"D" | "R" | "I" | "U", number> = {
+      D: 0,
+      R: 0,
+      I: 0,
+      U: 0,
+    };
+    const partyLawCounts: Record<"D" | "R" | "I" | "U", number> = {
+      D: 0,
+      R: 0,
+      I: 0,
+      U: 0,
+    };
+    const stateCounts = new Map<string, number>();
+    const monthCounts = new Map<string, { total: number; law: number }>();
+    let total = 0;
+
+    for (const billType of billTypes) {
+      let cursor: string | null = null;
+      for (;;) {
+        const page: ChamberBillPageResult = await ctx.runQuery(
+          internal.mutations.getChamberBillsPage,
+          {
+            congress: args.congress,
+            billType,
+            cursor,
+            numItems: 2000,
+          },
+        );
+        for (const bill of page.page) {
+          total += 1;
+          const party = normaliseParty(bill.sponsorParty);
+          const isLaw = bill.progressStage === 100;
+          partyCounts[party] += 1;
+          if (isLaw) partyLawCounts[party] += 1;
+
+          // Only aggregate valid ASCII state codes — keeps the homepage
+          // top-states list clean and avoids polluting the table with
+          // "Unknown".
+          if (
+            bill.sponsorState &&
+            /^[A-Z]{2,3}$/.test(bill.sponsorState)
+          ) {
+            stateCounts.set(
+              bill.sponsorState,
+              (stateCounts.get(bill.sponsorState) || 0) + 1,
+            );
+          }
+
+          // introducedDate is "YYYY-MM-DD"; bucket by month.
+          const month = (bill.introducedDate || "").slice(0, 7);
+          if (month) {
+            const entry = monthCounts.get(month) || {
+              total: 0,
+              law: 0,
+            };
+            entry.total += 1;
+            if (isLaw) entry.law += 1;
+            monthCounts.set(month, entry);
+          }
+        }
+        if (page.isDone) break;
+        cursor = page.continueCursor;
+      }
+    }
+
+    const stateCountsArr = [...stateCounts.entries()]
+      .map(([state, count]) => ({ state, count }))
+      .sort((a, b) => b.count - a.count);
+    const monthly = [...monthCounts.entries()]
+      .map(([month, v]) => ({
+        month,
+        count: v.total,
+        becameLaw: v.law,
+      }))
+      .sort((a, b) => a.month.localeCompare(b.month));
+
+    await ctx.runMutation(
+      internal.mutations.writeCongressChamberBreakdown,
+      {
+        congress: args.congress,
+        chamber: args.chamber,
+        total,
+        partyCounts,
+        partyLawCounts,
+        stateCounts: stateCountsArr,
+        monthly,
+      },
+    );
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -123,6 +123,41 @@ export default defineSchema({
     .index("by_congress", ["congress"])
     .index("by_congress_and_count", ["congress", "billCount"]),
 
+  // Precomputed party / state / monthly aggregations per (congress, chamber).
+  // Replaces the per-load 13K-doc scan in getChamberDeepBreakdown — homepage
+  // reads a single row via the by_congress_and_chamber index.
+  congressChamberBreakdowns: defineTable({
+    congress: v.number(),
+    chamber: v.union(v.literal("house"), v.literal("senate")),
+    total: v.number(),
+    partyCounts: v.object({
+      D: v.number(),
+      R: v.number(),
+      I: v.number(),
+      U: v.number(),
+    }),
+    partyLawCounts: v.object({
+      D: v.number(),
+      R: v.number(),
+      I: v.number(),
+      U: v.number(),
+    }),
+    // Stored as array (not record) to keep the validator simple — Convex
+    // object keys must be valid identifiers and we don't want to risk
+    // edge-case state codes breaking the schema.
+    stateCounts: v.array(
+      v.object({ state: v.string(), count: v.number() }),
+    ),
+    monthly: v.array(
+      v.object({
+        month: v.string(),
+        count: v.number(),
+        becameLaw: v.number(),
+      }),
+    ),
+    updatedAt: v.string(),
+  }).index("by_congress_and_chamber", ["congress", "chamber"]),
+
   // Bill chat sessions — one per (billId, sessionId) pair
   billChats: defineTable({
     billId: v.string(),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Enables Partial Prerendering — homepage shell prerenders, the cached
+  // dashboard data flushes from the edge, and any dynamic Suspense content
+  // streams in. Required for the `'use cache'` directive in app/page.tsx.
+  cacheComponents: true,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
…amber breakdown

Cuts cold-load time from ~5s to <1s on cache hits. The shell prerenders, the dashboard data ships inline in the HTML, and the Convex websocket only opens when the user switches Congresses.

Frontend (ships with this commit):
- app/page.tsx: convert from `'use client'` + dynamic({ ssr: false }) to a server component that fetches all four dashboard queries in parallel via fetchQuery from convex/nextjs; wrap in <Suspense> for PPR streaming
- Add `'use cache'` + cacheLife({ stale: 60, revalidate: 600, expire: 3600 }) on the loader; per-Congress cacheTag for targeted invalidation
- DashboardClient: accepts initialData prop, uses the 'skip' sentinel on useQuery for the SSR'd Congress so the websocket stays closed by default
- next.config.mjs: enable cacheComponents
- /bills/[id]: migrate `revalidate = 3600` → `'use cache'` + cacheLife (required by Cache Components)
- navigation.tsx: defer `new Date()` to useEffect; footer.tsx: async + cached (both were breaking prerender)

Backend (committed but NOT deployed yet — see note):
- New `congressChamberBreakdowns` aggregate table in convex/schema.ts
- Paginated recompute action mirroring the policy-areas / sponsors pattern; recomputeAllStats and syncBillBatch refresh it after each sync
- getChamberDeepBreakdown rewritten as a single index lookup (was a 13K-doc scan dominating cold-load latency)

Deploy note: skipping `npx convex deploy` from this branch — production currently has auth/Stripe tables from the parallel auth branch (claude/angry-goodall-441dd8) that aren't in this branch's schema.ts. Deploying from here would remove those indexes. Once both branches land on main, deploy together and then run
`npx convex run congressApi:triggerRecomputeStats` once to populate the new aggregate table — that's when Layer 1 perf activates.