### PR TITLE
feat: auth + email verification substrate (PR 1)

### DIFF
--- a/app/ConvexClientProvider.tsx
+++ b/app/ConvexClientProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { ConvexAuthNextjsProvider } from "@convex-dev/auth/nextjs";
+import { ConvexReactClient } from "convex/react";
 import { createContext, ReactNode, useContext } from "react";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
@@ -10,9 +11,10 @@ const convex = convexUrl ? new ConvexReactClient(convexUrl) : null;
 const ConvexEnabledContext = createContext(false);
 
 /**
- * Returns true when Convex is configured and the ConvexProvider is active.
- * Components that call Convex hooks (useQuery, useMutation, etc.) must
- * gate on this to avoid the "missing provider" runtime error.
+ * Returns true when Convex is configured and the ConvexAuthNextjsProvider is
+ * active. Components that call Convex hooks (useQuery, useMutation, useAuth,
+ * etc.) must gate on this to avoid the "missing provider" runtime error in
+ * environments where NEXT_PUBLIC_CONVEX_URL isn't set (e.g. pre-build SSR).
  */
 export function useConvexEnabled() {
   return useContext(ConvexEnabledContext);
@@ -28,7 +30,9 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
   }
   return (
     <ConvexEnabledContext.Provider value={true}>
-      <ConvexProvider client={convex}>{children}</ConvexProvider>
+      <ConvexAuthNextjsProvider client={convex}>
+        {children}
+      </ConvexAuthNextjsProvider>
     </ConvexEnabledContext.Provider>
   );
 }

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useQuery } from "convex/react";
+import { useAuthActions } from "@convex-dev/auth/react";
+
+import { api } from "@/convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useConvexEnabled } from "@/app/ConvexClientProvider";
+
+export default function AccountPage() {
+  const enabled = useConvexEnabled();
+  if (!enabled) {
+    return (
+      <div className="container-editorial py-16">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+  return <AccountInner />;
+}
+
+function AccountInner() {
+  const user = useQuery(api.users.currentUser, {});
+  const { signOut } = useAuthActions();
+
+  if (user === undefined) {
+    return (
+      <div className="container-editorial py-16">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (user === null) {
+    // Middleware should have redirected, but if a query desync happened, show a hint.
+    return (
+      <div className="container-editorial py-16">
+        <p className="text-sm text-muted-foreground">
+          Not signed in.{" "}
+          <Link href="/sign-in" className="underline">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  const verified = Boolean(user.emailVerificationTime);
+
+  return (
+    <div className="container-editorial py-16 space-y-10">
+      <header className="space-y-2">
+        <p className="label-eyebrow">Account</p>
+        <h1 className="font-serif text-3xl font-semibold tracking-tight">
+          {user.name ?? user.email ?? "Your account"}
+        </h1>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Profile</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div>
+              <p className="text-muted-foreground text-xs uppercase tracking-wider">Name</p>
+              <p>{user.name ?? "—"}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs uppercase tracking-wider">Email</p>
+              <p className="flex items-center gap-2">
+                {user.email ?? "—"}
+                {verified ? (
+                  <span className="rounded-sm bg-emerald-500/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+                    Verified
+                  </span>
+                ) : (
+                  <span className="rounded-sm bg-amber-500/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-300">
+                    Unverified
+                  </span>
+                )}
+              </p>
+            </div>
+            {!verified && (
+              <p className="text-xs text-muted-foreground">
+                Verify your email before upgrading to Pro. Check your inbox for a 6-digit code, or
+                sign out and sign in again to receive a new one.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Plan</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div>
+              <p className="text-muted-foreground text-xs uppercase tracking-wider">Current plan</p>
+              <p className="text-xl font-serif">{user.plan === "pro" ? "Pro" : "Free"}</p>
+            </div>
+            {user.plan === "pro" ? (
+              <p className="text-xs text-muted-foreground">
+                Billing is managed in the Stripe Customer Portal. (Coming in PR 2.)
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Pro adds daily bill digests, generated bill audio, and more. Pricing page coming in PR 2.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="border-t border-border pt-6">
+        <Button
+          variant="outline"
+          onClick={async () => {
+            await signOut();
+            window.location.href = "/";
+          }}
+        >
+          Sign out
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Forgot your password?",
+  description: "Reset your Bills.Congress password.",
+};
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="container-editorial flex flex-1 items-center justify-center py-16">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div className="space-y-2">
+          <h1 className="font-serif text-3xl font-semibold tracking-tight">
+            Reset your password
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Password reset by email is coming soon. While we finish wiring it
+            up, please reach out and we&apos;ll reset it manually.
+          </p>
+        </div>
+        <div className="rounded-sm border border-border bg-background/50 px-4 py-4 text-left text-sm space-y-2">
+          <p className="text-foreground font-medium">In the meantime</p>
+          <ul className="list-disc list-inside text-muted-foreground space-y-1">
+            <li>Sign in with Google if you used Google before</li>
+            <li>
+              Email{" "}
+              <a
+                href="mailto:hi@mail.billsincongress.com"
+                className="text-foreground underline"
+              >
+                hi@mail.billsincongress.com
+              </a>{" "}
+              and we&apos;ll reset it for you
+            </li>
+          </ul>
+        </div>
+        <Link
+          href="/sign-in"
+          className="inline-block text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back to sign in
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { Fraunces, Inter, JetBrains_Mono } from 'next/font/google';
+import { ConvexAuthNextjsServerProvider } from '@convex-dev/auth/nextjs/server';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Navigation } from '@/components/navigation';
 import { Footer } from '@/components/footer';
@@ -76,32 +77,34 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html
-      lang="en"
-      suppressHydrationWarning
-      className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
-    >
-      <body className="min-h-screen bg-background text-foreground font-sans antialiased">
-        <ConvexClientProvider>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <a
-              href="#main"
-              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded focus:bg-foreground focus:text-background focus:px-3 focus:py-2 focus:text-sm"
-            >
-              Skip to content
-            </a>
-            <div className="flex min-h-screen flex-col">
-              <Navigation />
-              <main id="main" className="flex-1">
-                {children}
-              </main>
-              <Footer />
-            </div>
-            <Analytics />
-            <Toaster />
-          </ThemeProvider>
-        </ConvexClientProvider>
-      </body>
-    </html>
+    <ConvexAuthNextjsServerProvider>
+      <html
+        lang="en"
+        suppressHydrationWarning
+        className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+      >
+        <body className="min-h-screen bg-background text-foreground font-sans antialiased">
+          <ConvexClientProvider>
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+              <a
+                href="#main"
+                className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded focus:bg-foreground focus:text-background focus:px-3 focus:py-2 focus:text-sm"
+              >
+                Skip to content
+              </a>
+              <div className="flex min-h-screen flex-col">
+                <Navigation />
+                <main id="main" className="flex-1">
+                  {children}
+                </main>
+                <Footer />
+              </div>
+              <Analytics />
+              <Toaster />
+            </ThemeProvider>
+          </ConvexClientProvider>
+        </body>
+      </html>
+    </ConvexAuthNextjsServerProvider>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import { Suspense } from 'react';
 import type { Metadata, Viewport } from 'next';
 import { Fraunces, Inter, JetBrains_Mono } from 'next/font/google';
 import { ConvexAuthNextjsServerProvider } from '@convex-dev/auth/nextjs/server';
@@ -76,35 +77,41 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // ConvexAuthNextjsServerProvider reads request cookies (dynamic data) so
+  // its render must be inside a Suspense boundary under Cache Components.
+  // The shell (html/body) prerenders statically; the auth-aware tree streams
+  // from inside the provider once cookies are read.
   return (
-    <ConvexAuthNextjsServerProvider>
-      <html
-        lang="en"
-        suppressHydrationWarning
-        className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
-      >
-        <body className="min-h-screen bg-background text-foreground font-sans antialiased">
-          <ConvexClientProvider>
-            <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-              <a
-                href="#main"
-                className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded focus:bg-foreground focus:text-background focus:px-3 focus:py-2 focus:text-sm"
-              >
-                Skip to content
-              </a>
-              <div className="flex min-h-screen flex-col">
-                <Navigation />
-                <main id="main" className="flex-1">
-                  {children}
-                </main>
-                <Footer />
-              </div>
-              <Analytics />
-              <Toaster />
-            </ThemeProvider>
-          </ConvexClientProvider>
-        </body>
-      </html>
-    </ConvexAuthNextjsServerProvider>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="min-h-screen bg-background text-foreground font-sans antialiased">
+        <Suspense fallback={null}>
+          <ConvexAuthNextjsServerProvider>
+            <ConvexClientProvider>
+              <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+                <a
+                  href="#main"
+                  className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded focus:bg-foreground focus:text-background focus:px-3 focus:py-2 focus:text-sm"
+                >
+                  Skip to content
+                </a>
+                <div className="flex min-h-screen flex-col">
+                  <Navigation />
+                  <main id="main" className="flex-1">
+                    {children}
+                  </main>
+                  <Footer />
+                </div>
+                <Analytics />
+                <Toaster />
+              </ThemeProvider>
+            </ConvexClientProvider>
+          </ConvexAuthNextjsServerProvider>
+        </Suspense>
+      </body>
+    </html>
   );
 }

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+
+import { SignInForm } from "@/components/auth/sign-in-form";
+
+export const metadata: Metadata = {
+  title: "Sign in",
+  description: "Sign in to your Bills.Congress account.",
+};
+
+export default function SignInPage() {
+  return (
+    <div className="container-editorial flex flex-1 items-center justify-center py-16">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="space-y-2 text-center">
+          <h1 className="font-serif text-3xl font-semibold tracking-tight">
+            Welcome back
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Sign in to follow bills, save your work, and access Pro features.
+          </p>
+        </div>
+        <Suspense fallback={<div className="h-72" aria-hidden />}>
+          <SignInForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+
+import { SignUpForm } from "@/components/auth/sign-up-form";
+
+export const metadata: Metadata = {
+  title: "Create your account",
+  description: "Sign up for a Bills.Congress account.",
+};
+
+export default function SignUpPage() {
+  return (
+    <div className="container-editorial flex flex-1 items-center justify-center py-16">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="space-y-2 text-center">
+          <h1 className="font-serif text-3xl font-semibold tracking-tight">
+            Create your account
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Free forever. Upgrade to Pro any time.
+          </p>
+        </div>
+        <Suspense fallback={<div className="h-96" aria-hidden />}>
+          <SignUpForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/google-button.tsx
+++ b/components/auth/google-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { Button } from "@/components/ui/button";
+
+interface GoogleButtonProps {
+  redirectTo?: string;
+  label?: string;
+}
+
+export function GoogleButton({ redirectTo = "/account", label = "Continue with Google" }: GoogleButtonProps) {
+  const { signIn } = useAuthActions();
+  const [busy, setBusy] = React.useState(false);
+
+  async function onClick() {
+    setBusy(true);
+    try {
+      // Convex SITE_URL is the prod website. For local dev, we want OAuth to
+      // come back to localhost, so resolve `redirectTo` against the current
+      // origin and pass an absolute URL.
+      const absolute = redirectTo.startsWith("http")
+        ? redirectTo
+        : new URL(redirectTo, window.location.origin).toString();
+      await signIn("google", { redirectTo: absolute });
+    } catch (err) {
+      console.error("Google sign-in failed", err);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className="w-full justify-center gap-2 font-sans"
+      onClick={onClick}
+      disabled={busy}
+    >
+      <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.75h3.57c2.08-1.92 3.28-4.74 3.28-8.07z" fill="#4285F4"/>
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.75c-.99.66-2.25 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+        <path d="M5.84 14.12c-.22-.66-.35-1.36-.35-2.12s.13-1.46.35-2.12V7.04H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.96l3.66-2.84z" fill="#FBBC05"/>
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.04l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z" fill="#EA4335"/>
+      </svg>
+      {label}
+    </Button>
+  );
+}

--- a/components/auth/sign-in-form.tsx
+++ b/components/auth/sign-in-form.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import * as React from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { GoogleButton } from "./google-button";
+
+export function SignInForm() {
+  const { signIn } = useAuthActions();
+  const router = useRouter();
+  const params = useSearchParams();
+  const redirect = params.get("redirect") ?? "/account";
+
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await signIn("password", { email, password, flow: "signIn" });
+      router.push(redirect);
+    } catch (err) {
+      console.error("Sign-in failed", err);
+      setError(
+        err instanceof Error && err.message.includes("InvalidAccountId")
+          ? "No account with that email and password."
+          : "Sign-in failed. Check your email and password and try again.",
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <GoogleButton redirectTo={redirect} label="Sign in with Google" />
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-border" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase tracking-wider">
+          <span className="bg-background px-2 text-muted-foreground">or with email</span>
+        </div>
+      </div>
+
+      <form method="post" onSubmit={onSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={busy}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={busy}
+          />
+        </div>
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        <Button type="submit" className="w-full" disabled={busy}>
+          {busy ? "Signing in…" : "Sign in"}
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Don&apos;t have an account?{" "}
+        <Link href="/sign-up" className="font-medium text-foreground hover:underline">
+          Sign up
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/components/auth/sign-in-form.tsx
+++ b/components/auth/sign-in-form.tsx
@@ -14,8 +14,9 @@ export function SignInForm() {
   const router = useRouter();
   const params = useSearchParams();
   const redirect = params.get("redirect") ?? "/account";
+  const prefillEmail = params.get("email") ?? "";
 
-  const [email, setEmail] = React.useState("");
+  const [email, setEmail] = React.useState(prefillEmail);
   const [password, setPassword] = React.useState("");
   const [busy, setBusy] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -28,12 +29,24 @@ export function SignInForm() {
       await signIn("password", { email, password, flow: "signIn" });
       router.push(redirect);
     } catch (err) {
-      console.error("Sign-in failed", err);
-      setError(
-        err instanceof Error && err.message.includes("InvalidAccountId")
-          ? "No account with that email and password."
-          : "Sign-in failed. Check your email and password and try again.",
-      );
+      // console.warn (not error) so the Next.js dev overlay doesn't pop for
+      // expected auth failures like wrong password — those should only be
+      // shown via the friendly form message below.
+      console.warn("Sign-in failed", err);
+      const msg = err instanceof Error ? err.message.toLowerCase() : "";
+      // Vague error on sign-in (no email enumeration). Wrong-email and
+      // wrong-password both surface as "InvalidAccountId" or as the wrapped
+      // generic "Server Error" — both should look identical to the user.
+      if (
+        msg.includes("invalidaccountid") ||
+        msg.includes("invalid credentials") ||
+        msg.includes("server error") ||
+        msg.includes("[request id")
+      ) {
+        setError("Invalid email or password. Try again, or reset your password if you forgot it.");
+      } else {
+        setError("Sign-in failed. Please try again in a moment.");
+      }
       setBusy(false);
     }
   }
@@ -66,7 +79,15 @@ export function SignInForm() {
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="password">Password</Label>
+          <div className="flex items-baseline justify-between">
+            <Label htmlFor="password">Password</Label>
+            <Link
+              href={`/forgot-password${email ? `?email=${encodeURIComponent(email)}` : ""}`}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Forgot password?
+            </Link>
+          </div>
           <Input
             id="password"
             name="password"

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -4,6 +4,9 @@ import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useConvex } from "convex/react";
+
+import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,8 +16,14 @@ type Step = "credentials" | "verify";
 
 const PASSWORD_RULES = "At least 10 characters, with upper-, lower-case, and a number.";
 
+type ErrorState =
+  | null
+  | { kind: "message"; text: string }
+  | { kind: "alreadyExists"; email: string };
+
 export function SignUpForm() {
   const { signIn } = useAuthActions();
+  const convex = useConvex();
   const router = useRouter();
   const params = useSearchParams();
   const redirect = params.get("redirect") ?? "/account";
@@ -24,7 +33,7 @@ export function SignUpForm() {
   const [password, setPassword] = React.useState("");
   const [code, setCode] = React.useState("");
   const [busy, setBusy] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<ErrorState>(null);
 
   function validatePassword(pw: string): string | null {
     if (pw.length < 10) return "Password must be at least 10 characters.";
@@ -38,21 +47,47 @@ export function SignUpForm() {
     e.preventDefault();
     const pwError = validatePassword(password);
     if (pwError) {
-      setError(pwError);
+      setError({ kind: "message", text: pwError });
       return;
     }
     setBusy(true);
     setError(null);
     try {
+      // Pre-check: if a password account already exists for this email, the
+      // library will throw a generic "Server Error". Detect first so we can
+      // give a clean "already registered" UX instead.
+      const exists = await convex.query(api.users.isEmailRegistered, { email });
+      if (exists) {
+        setError({ kind: "alreadyExists", email });
+        setBusy(false);
+        return;
+      }
+
       await signIn("password", { email, password, flow: "signUp" });
       setStep("verify");
     } catch (err) {
-      console.error("Sign-up failed", err);
-      setError(
-        err instanceof Error && err.message.toLowerCase().includes("already")
-          ? "An account with that email already exists. Try signing in."
-          : "Sign-up failed. Try a different email or check your password.",
-      );
+      console.warn("Sign-up failed", err);
+      const msg = err instanceof Error ? err.message.toLowerCase() : "";
+      // Belt-and-suspenders: still match the wrapped "Server Error" in case the
+      // pre-check raced with another signup. We assume "already exists" because
+      // that's the dominant signUp failure mode.
+      if (
+        msg.includes("already exists") ||
+        msg.includes("server error") ||
+        msg.includes("[request id")
+      ) {
+        setError({ kind: "alreadyExists", email });
+      } else if (msg.includes("password")) {
+        setError({
+          kind: "message",
+          text: "Password didn't meet requirements. " + PASSWORD_RULES,
+        });
+      } else {
+        setError({
+          kind: "message",
+          text: "Sign-up failed. Check your email and password and try again.",
+        });
+      }
     } finally {
       setBusy(false);
     }
@@ -70,8 +105,11 @@ export function SignUpForm() {
       });
       router.push(redirect);
     } catch (err) {
-      console.error("Verification failed", err);
-      setError("That code didn't work. Check your email and try again.");
+      console.warn("Verification failed", err);
+      setError({
+        kind: "message",
+        text: "That code didn't work. Check your email and try again.",
+      });
       setBusy(false);
     }
   }
@@ -83,8 +121,11 @@ export function SignUpForm() {
       // Re-running signUp re-sends the code through the verify provider.
       await signIn("password", { email, password, flow: "signUp" });
     } catch (err) {
-      console.error("Resend failed", err);
-      setError("Could not resend the code. Try again in a minute.");
+      console.warn("Resend failed", err);
+      setError({
+        kind: "message",
+        text: "Could not resend the code. Try again in a minute.",
+      });
     } finally {
       setBusy(false);
     }
@@ -121,8 +162,8 @@ export function SignUpForm() {
               className="font-mono tracking-widest text-center"
             />
           </div>
-          {error && (
-            <p className="text-sm text-destructive" role="alert">{error}</p>
+          {error?.kind === "message" && (
+            <p className="text-sm text-destructive" role="alert">{error.text}</p>
           )}
           <Button type="submit" className="w-full" disabled={busy || code.length !== 6}>
             {busy ? "Verifying…" : "Verify email"}
@@ -199,8 +240,45 @@ export function SignUpForm() {
             {PASSWORD_RULES}
           </p>
         </div>
-        {error && (
-          <p className="text-sm text-destructive" role="alert">{error}</p>
+        {error?.kind === "message" && (
+          <p className="text-sm text-destructive" role="alert">{error.text}</p>
+        )}
+        {error?.kind === "alreadyExists" && (
+          <div
+            className="rounded-sm border border-amber-500/30 bg-amber-500/10 px-3 py-3 text-sm space-y-2"
+            role="alert"
+          >
+            <p className="text-foreground">
+              An account with <span className="font-medium">{error.email}</span>{" "}
+              already exists.
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <Link
+                href={`/sign-in?email=${encodeURIComponent(error.email)}&redirect=${encodeURIComponent(redirect)}`}
+                className="font-medium text-foreground underline underline-offset-4 hover:no-underline"
+              >
+                Sign in instead
+              </Link>
+              <span className="text-muted-foreground">·</span>
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  setStep("verify");
+                }}
+                className="text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+              >
+                I have a verification code
+              </button>
+              <span className="text-muted-foreground">·</span>
+              <Link
+                href={`/forgot-password?email=${encodeURIComponent(error.email)}`}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                Forgot password?
+              </Link>
+            </div>
+          </div>
         )}
         <Button type="submit" className="w-full" disabled={busy}>
           {busy ? "Creating account…" : "Create account"}

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import * as React from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { GoogleButton } from "./google-button";
+
+type Step = "credentials" | "verify";
+
+const PASSWORD_RULES = "At least 10 characters, with upper-, lower-case, and a number.";
+
+export function SignUpForm() {
+  const { signIn } = useAuthActions();
+  const router = useRouter();
+  const params = useSearchParams();
+  const redirect = params.get("redirect") ?? "/account";
+
+  const [step, setStep] = React.useState<Step>("credentials");
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [code, setCode] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  function validatePassword(pw: string): string | null {
+    if (pw.length < 10) return "Password must be at least 10 characters.";
+    if (!/[a-z]/.test(pw) || !/[A-Z]/.test(pw) || !/\d/.test(pw)) {
+      return "Password needs upper-, lower-case, and a number.";
+    }
+    return null;
+  }
+
+  async function onCredentialsSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const pwError = validatePassword(password);
+    if (pwError) {
+      setError(pwError);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await signIn("password", { email, password, flow: "signUp" });
+      setStep("verify");
+    } catch (err) {
+      console.error("Sign-up failed", err);
+      setError(
+        err instanceof Error && err.message.toLowerCase().includes("already")
+          ? "An account with that email already exists. Try signing in."
+          : "Sign-up failed. Try a different email or check your password.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onVerifySubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      await signIn("password", {
+        email,
+        code,
+        flow: "email-verification",
+      });
+      router.push(redirect);
+    } catch (err) {
+      console.error("Verification failed", err);
+      setError("That code didn't work. Check your email and try again.");
+      setBusy(false);
+    }
+  }
+
+  async function onResend() {
+    setBusy(true);
+    setError(null);
+    try {
+      // Re-running signUp re-sends the code through the verify provider.
+      await signIn("password", { email, password, flow: "signUp" });
+    } catch (err) {
+      console.error("Resend failed", err);
+      setError("Could not resend the code. Try again in a minute.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (step === "verify") {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            We sent a 6-digit code to <span className="font-medium text-foreground">{email}</span>.
+            It expires in 15 minutes.
+          </p>
+        </div>
+        <form
+          method="post"
+          onSubmit={onVerifySubmit}
+          className="space-y-4"
+        >
+          <div className="space-y-1.5">
+            <Label htmlFor="code">Verification code</Label>
+            <Input
+              id="code"
+              name="code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              pattern="\d{6}"
+              maxLength={6}
+              required
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              disabled={busy}
+              className="font-mono tracking-widest text-center"
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-destructive" role="alert">{error}</p>
+          )}
+          <Button type="submit" className="w-full" disabled={busy || code.length !== 6}>
+            {busy ? "Verifying…" : "Verify email"}
+          </Button>
+        </form>
+        <div className="flex items-center justify-between text-sm">
+          <button
+            type="button"
+            onClick={() => setStep("credentials")}
+            className="text-muted-foreground hover:text-foreground"
+            disabled={busy}
+          >
+            ← Use a different email
+          </button>
+          <button
+            type="button"
+            onClick={onResend}
+            className="text-muted-foreground hover:text-foreground"
+            disabled={busy}
+          >
+            Resend code
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <GoogleButton redirectTo={redirect} label="Sign up with Google" />
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-border" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase tracking-wider">
+          <span className="bg-background px-2 text-muted-foreground">or with email</span>
+        </div>
+      </div>
+
+      <form
+        method="post"
+        onSubmit={onCredentialsSubmit}
+        className="space-y-4"
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={busy}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            required
+            minLength={10}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={busy}
+            aria-describedby="password-rules"
+          />
+          <p id="password-rules" className="text-xs text-muted-foreground">
+            {PASSWORD_RULES}
+          </p>
+        </div>
+        {error && (
+          <p className="text-sm text-destructive" role="alert">{error}</p>
+        )}
+        <Button type="submit" className="w-full" disabled={busy}>
+          {busy ? "Creating account…" : "Create account"}
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Already have an account?{" "}
+        <Link href="/sign-in" className="font-medium text-foreground hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/components/auth/user-menu.tsx
+++ b/components/auth/user-menu.tsx
@@ -33,14 +33,26 @@ function initialsFor(nameOrEmail: string | undefined | null): string {
 
 export function UserMenu() {
   const enabled = useConvexEnabled();
-  if (!enabled) return null;
+  // Only render after client mount. With Cache Components enabled at the
+  // root layout, ConvexAuthNextjsProvider's React context isn't populated
+  // during prerender — useConvexAuth() returns undefined and destructuring
+  // crashes the build. Skipping render until mount avoids this and the
+  // hydration happens cleanly once the client provider is live.
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+  if (!enabled || !mounted) {
+    // Reserve the slot's space so the layout doesn't shift after hydration.
+    return <div aria-hidden className="h-9 w-9" />;
+  }
   return <UserMenuInner />;
 }
 
 function UserMenuInner() {
-  const { isLoading, isAuthenticated } = useConvexAuth();
+  const auth = useConvexAuth();
   const { signOut } = useAuthActions();
   const router = useRouter();
+  const isAuthenticated = auth?.isAuthenticated ?? false;
+  const isLoading = auth?.isLoading ?? true;
   const user = useQuery(api.users.currentUser, isAuthenticated ? {} : "skip");
 
   if (isLoading) {

--- a/components/auth/user-menu.tsx
+++ b/components/auth/user-menu.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useQuery } from "convex/react";
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useConvexAuth } from "convex/react";
+import { LogOut, User as UserIcon } from "lucide-react";
+
+import { api } from "@/convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useConvexEnabled } from "@/app/ConvexClientProvider";
+
+function initialsFor(nameOrEmail: string | undefined | null): string {
+  if (!nameOrEmail) return "·";
+  const trimmed = nameOrEmail.trim();
+  const atIdx = trimmed.indexOf("@");
+  const base = atIdx > 0 ? trimmed.slice(0, atIdx) : trimmed;
+  const parts = base.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length === 0) return "·";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function UserMenu() {
+  const enabled = useConvexEnabled();
+  if (!enabled) return null;
+  return <UserMenuInner />;
+}
+
+function UserMenuInner() {
+  const { isLoading, isAuthenticated } = useConvexAuth();
+  const { signOut } = useAuthActions();
+  const router = useRouter();
+  const user = useQuery(api.users.currentUser, isAuthenticated ? {} : "skip");
+
+  if (isLoading) {
+    return (
+      <div
+        aria-hidden
+        className="h-9 w-9 rounded-full border border-border bg-muted/40"
+      />
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Button asChild variant="ghost" size="sm" className="font-medium">
+        <Link href="/sign-in">Sign in</Link>
+      </Button>
+    );
+  }
+
+  const displayName = user?.name ?? user?.email ?? "Account";
+  const initials = initialsFor(user?.name ?? user?.email);
+  const verified = Boolean(user?.emailVerificationTime);
+
+  async function onSignOut() {
+    await signOut();
+    router.push("/");
+    router.refresh();
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Account menu"
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-muted/30 text-xs font-semibold uppercase text-foreground transition-colors hover:bg-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {initials}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-60">
+        <DropdownMenuLabel className="px-2 pb-1 pt-2">
+          <div className="space-y-0.5 normal-case tracking-normal">
+            <p className="text-sm font-medium text-foreground truncate">{displayName}</p>
+            {user?.email && user.email !== displayName && (
+              <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {user?.plan === "pro" ? "Pro plan" : "Free plan"}
+              {!verified && " · email unverified"}
+            </p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/account" className="cursor-pointer">
+            <UserIcon className="mr-2 h-4 w-4" /> Account
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onSignOut} className="cursor-pointer">
+          <LogOut className="mr-2 h-4 w-4" /> Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Menu, X } from 'lucide-react';
 import { routes } from '@/lib/constants/routes';
+import { UserMenu } from '@/components/auth/user-menu';
 
 export function Navigation() {
   const [open, setOpen] = React.useState(false);
@@ -119,6 +120,11 @@ export function Navigation() {
             );
           })}
         </nav>
+
+        {/* Account slot — UserMenu when authed, Sign in link when not */}
+        <div className="ml-auto md:ml-0 flex items-center">
+          <UserMenu />
+        </div>
       </div>
     </header>
   );

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[10rem] overflow-hidden rounded-md border border-border bg-background p-1 text-foreground shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-secondary focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-secondary",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-secondary",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-xs uppercase tracking-wider text-muted-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName =
+  DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/convex/ResendOTP.ts
+++ b/convex/ResendOTP.ts
@@ -1,0 +1,43 @@
+import Resend from "@auth/core/providers/resend";
+import { Resend as ResendAPI } from "resend";
+
+// 6-digit numeric verification code, expires in 15 minutes.
+// Used on signup and on `resendVerificationEmail`.
+
+function generateOTP(): string {
+  // Web Crypto is available in the Convex runtime.
+  const buf = new Uint8Array(6);
+  crypto.getRandomValues(buf);
+  let out = "";
+  for (let i = 0; i < 6; i++) out += (buf[i] % 10).toString();
+  return out;
+}
+
+export const ResendOTP = Resend({
+  id: "resend-otp",
+  apiKey: process.env.AUTH_RESEND_KEY,
+  maxAge: 60 * 15, // 15 minutes
+  async generateVerificationToken() {
+    return generateOTP();
+  },
+  async sendVerificationRequest({ identifier: email, provider, token }) {
+    const resend = new ResendAPI(provider.apiKey);
+    const from = process.env.AUTH_EMAIL_FROM ?? "Bills.Congress <onboarding@resend.dev>";
+    const { error } = await resend.emails.send({
+      from,
+      to: [email],
+      subject: "Verify your email — Bills.Congress",
+      text: [
+        `Your verification code is ${token}.`,
+        "",
+        "It expires in 15 minutes.",
+        "",
+        "If you didn't request this, you can safely ignore it.",
+      ].join("\n"),
+    });
+    if (error) {
+      console.error("Resend verification email failed", error);
+      throw new Error("Could not send verification email.");
+    }
+  },
+});

--- a/convex/ResendOTPPasswordReset.ts
+++ b/convex/ResendOTPPasswordReset.ts
@@ -1,0 +1,42 @@
+import Resend from "@auth/core/providers/resend";
+import { Resend as ResendAPI } from "resend";
+
+// Distinct provider id from ResendOTP — the auth library uses the id
+// to differentiate verify-email vs reset-password code flows.
+
+function generateOTP(): string {
+  const buf = new Uint8Array(6);
+  crypto.getRandomValues(buf);
+  let out = "";
+  for (let i = 0; i < 6; i++) out += (buf[i] % 10).toString();
+  return out;
+}
+
+export const ResendOTPPasswordReset = Resend({
+  id: "resend-otp-password-reset",
+  apiKey: process.env.AUTH_RESEND_KEY,
+  maxAge: 60 * 15,
+  async generateVerificationToken() {
+    return generateOTP();
+  },
+  async sendVerificationRequest({ identifier: email, provider, token }) {
+    const resend = new ResendAPI(provider.apiKey);
+    const from = process.env.AUTH_EMAIL_FROM ?? "Bills.Congress <onboarding@resend.dev>";
+    const { error } = await resend.emails.send({
+      from,
+      to: [email],
+      subject: "Reset your password — Bills.Congress",
+      text: [
+        `Your password-reset code is ${token}.`,
+        "",
+        "It expires in 15 minutes.",
+        "",
+        "If you didn't request this, your account is safe — you can ignore it.",
+      ].join("\n"),
+    });
+    if (error) {
+      console.error("Resend password-reset email failed", error);
+      throw new Error("Could not send password-reset email.");
+    }
+  },
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,15 +8,20 @@
  * @module
  */
 
+import type * as ResendOTP from "../ResendOTP.js";
+import type * as ResendOTPPasswordReset from "../ResendOTPPasswordReset.js";
 import type * as aggregateBackfill from "../aggregateBackfill.js";
 import type * as aggregates from "../aggregates.js";
+import type * as auth from "../auth.js";
 import type * as bills from "../bills.js";
 import type * as congressApi from "../congressApi.js";
 import type * as crons from "../crons.js";
 import type * as functions from "../functions.js";
+import type * as http from "../http.js";
 import type * as llm from "../llm.js";
 import type * as mutations from "../mutations.js";
 import type * as sync from "../sync.js";
+import type * as users from "../users.js";
 
 import type {
   ApiFromModules,
@@ -25,15 +30,20 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  ResendOTP: typeof ResendOTP;
+  ResendOTPPasswordReset: typeof ResendOTPPasswordReset;
   aggregateBackfill: typeof aggregateBackfill;
   aggregates: typeof aggregates;
+  auth: typeof auth;
   bills: typeof bills;
   congressApi: typeof congressApi;
   crons: typeof crons;
   functions: typeof functions;
+  http: typeof http;
   llm: typeof llm;
   mutations: typeof mutations;
   sync: typeof sync;
+  users: typeof users;
 }>;
 
 /**

--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,0 +1,12 @@
+// JWT verification config read by Convex at function startup.
+// Without this file, ctx.auth.getUserIdentity() always returns null.
+// CONVEX_SITE_URL is auto-populated by `npx @convex-dev/auth`.
+
+export default {
+  providers: [
+    {
+      domain: process.env.CONVEX_SITE_URL,
+      applicationID: "convex",
+    },
+  ],
+};

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,0 +1,69 @@
+import Google from "@auth/core/providers/google";
+import { Password } from "@convex-dev/auth/providers/Password";
+import { convexAuth } from "@convex-dev/auth/server";
+import { ConvexError } from "convex/values";
+import { ResendOTP } from "./ResendOTP";
+import { ResendOTPPasswordReset } from "./ResendOTPPasswordReset";
+
+// Allow-list for OAuth `redirectTo`. The library defaults to "starts with
+// SITE_URL only" which blocks local dev (we test from http://localhost:3000
+// while SITE_URL is the prod site). We tightly restrict the dev allow-list:
+// HTTP only, the specific dev port, and the same hostnames Next.js binds.
+function isAllowedRedirect(url: URL): boolean {
+  const PROD_HOSTS = new Set([
+    "billsincongress.com",
+    "www.billsincongress.com",
+  ]);
+  if (url.protocol === "https:" && PROD_HOSTS.has(url.host)) return true;
+
+  const DEV_HOSTS = new Set(["localhost:3000", "127.0.0.1:3000"]);
+  if (url.protocol === "http:" && DEV_HOSTS.has(url.host)) return true;
+
+  return false;
+}
+
+export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
+  providers: [
+    // Google OAuth — uses AUTH_GOOGLE_ID + AUTH_GOOGLE_SECRET.
+    Google,
+
+    // Email + password with scrypt hashing (library default).
+    // Email verification + password reset are routed through Resend OTP helpers.
+    Password({
+      verify: ResendOTP,
+      reset: ResendOTPPasswordReset,
+      validatePasswordRequirements: (password: string) => {
+        if (password.length < 10) {
+          throw new ConvexError("Password must be at least 10 characters.");
+        }
+        if (
+          !/[a-z]/.test(password) ||
+          !/[A-Z]/.test(password) ||
+          !/\d/.test(password)
+        ) {
+          throw new ConvexError(
+            "Password must contain uppercase, lowercase, and a number.",
+          );
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    async redirect({ redirectTo }) {
+      // Relative paths are always safe — the library resolves them against SITE_URL.
+      if (!redirectTo.startsWith("http://") && !redirectTo.startsWith("https://")) {
+        return redirectTo;
+      }
+      let url: URL;
+      try {
+        url = new URL(redirectTo);
+      } catch {
+        throw new Error(`Invalid redirect URL: ${redirectTo}`);
+      }
+      if (!isAllowedRedirect(url)) {
+        throw new Error(`Unauthorized redirect target: ${url.origin}`);
+      }
+      return redirectTo;
+    },
+  },
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,24 @@
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { auth } from "./auth";
+
+const http = httpRouter();
+
+// Mounts /api/auth/* — the @convex-dev/auth library handles signin, signout,
+// callback, verify, refresh, etc. Required for the Next.js middleware to work.
+auth.addHttpRoutes(http);
+
+// Stub Stripe webhook. Returns 200 so we can register the endpoint with the
+// Stripe dashboard during PR 1 setup. PR 2 replaces this with the real
+// signature-verifying, idempotent handler in convex/stripe.ts.
+http.route({
+  path: "/stripe/webhook",
+  method: "POST",
+  handler: httpAction(async (_ctx, _req) => {
+    return new Response("stripe webhook stub — PR 2 implements", {
+      status: 200,
+    });
+  }),
+});
+
+export default http;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,7 +1,78 @@
 import { defineSchema, defineTable } from "convex/server";
+import { authTables } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  // ─── Auth + billing ─────────────────────────────────────────────────────────
+  // `authTables` provides: authAccounts, authSessions, authRefreshTokens,
+  // authVerificationCodes, authRateLimits. We override `users` below to add
+  // app-managed billing columns alongside the auth-managed identity fields.
+  ...authTables,
+
+  users: defineTable({
+    // Auth-managed (mirrors authTables.users shape so the library can write here)
+    name: v.optional(v.string()),
+    email: v.optional(v.string()),
+    image: v.optional(v.string()),
+    emailVerificationTime: v.optional(v.number()),
+    isAnonymous: v.optional(v.boolean()),
+
+    // App-managed billing. `plan` is optional in the schema because the
+    // @convex-dev/auth library inserts new users with only the auth fields
+    // (email/name/image) — it doesn't know about our app fields. Anywhere we
+    // read `plan`, treat undefined as "free". The `requirePro` helper checks
+    // for === "pro" so undefined is correctly excluded from Pro access.
+    plan: v.optional(v.union(v.literal("free"), v.literal("pro"))),
+    stripeCustomerId: v.optional(v.string()),
+    stripeSubscriptionId: v.optional(v.string()),
+    stripeSubscriptionStatus: v.optional(
+      v.union(
+        v.literal("active"),
+        v.literal("trialing"),
+        v.literal("past_due"),
+        v.literal("canceled"),
+        v.literal("incomplete"),
+        v.literal("incomplete_expired"),
+        v.literal("unpaid"),
+        v.literal("paused"),
+      ),
+    ),
+    stripePriceId: v.optional(v.string()),
+    stripeCurrentPeriodEnd: v.optional(v.number()), // unix seconds
+    cancelAtPeriodEnd: v.optional(v.boolean()),
+  })
+    .index("email", ["email"])
+    .index("by_stripeCustomerId", ["stripeCustomerId"])
+    .index("by_stripeSubscriptionId", ["stripeSubscriptionId"]),
+
+  // Stripe webhook idempotency. Every incoming event id is recorded; duplicate
+  // deliveries short-circuit to a 200 ack without re-applying side effects.
+  stripeEvents: defineTable({
+    eventId: v.string(),
+    type: v.string(),
+    receivedAt: v.number(),
+    processedAt: v.optional(v.number()),
+    status: v.union(
+      v.literal("received"),
+      v.literal("processed"),
+      v.literal("failed"),
+    ),
+    error: v.optional(v.string()),
+  }).index("by_eventId", ["eventId"]),
+
+  // Forward-compat audit log for Pro feature usage. `kind` is intentionally a
+  // free-form string so adding a new feature later doesn't require a migration.
+  usageEvents: defineTable({
+    userId: v.id("users"),
+    kind: v.string(),
+    billId: v.optional(v.string()),
+    createdAt: v.number(),
+    metadata: v.optional(v.any()),
+  })
+    .index("by_user_and_kind", ["userId", "kind"])
+    .index("by_user_and_createdAt", ["userId", "createdAt"]),
+
+  // ─── Bills domain ──────────────────────────────────────────────────────────
   // Main bill info table
   bills: defineTable({
     billId: v.string(), // Composite key: "{number}{type}{congress}" e.g. "1234hr119"
@@ -124,11 +195,16 @@ export default defineSchema({
     .index("by_congress_and_count", ["congress", "billCount"]),
 
   // Bill chat sessions — one per (billId, sessionId) pair
+  // `userId` is set only when the chatter is logged in. Anonymous chats keep
+  // `sessionId` only, preserving the existing flow for logged-out visitors.
   billChats: defineTable({
     billId: v.string(),
     sessionId: v.string(), // anonymous session ID stored in browser localStorage
+    userId: v.optional(v.id("users")),
     createdAt: v.string(),
-  }).index("by_billId_and_session", ["billId", "sessionId"]),
+  })
+    .index("by_billId_and_session", ["billId", "sessionId"])
+    .index("by_userId", ["userId"]),
 
   // Bill chat messages — individual turns in a chat session
   billChatMessages: defineTable({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -24,6 +24,29 @@ export const currentUser = query({
   },
 });
 
+/**
+ * Returns true if the given email already has a password authAccount.
+ * Used by the sign-up form to give a clean "already registered, try sign in"
+ * message instead of the generic "Server Error" the auth library throws.
+ *
+ * Email enumeration trade-off: this lets anyone probe whether a given email
+ * is registered. Standard for sign-up UX (most apps tell you the email is
+ * taken). For sign-IN we keep error messages vague (no enumeration there).
+ */
+export const isEmailRegistered = query({
+  args: { email: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, { email }) => {
+    const account = await ctx.db
+      .query("authAccounts")
+      .withIndex("providerAndAccountId", (q) =>
+        q.eq("provider", "password").eq("providerAccountId", email),
+      )
+      .first();
+    return account !== null;
+  },
+});
+
 // ─── Server-side helpers (not registered as functions) ─────────────────────
 
 type AnyDbCtx = QueryCtx | MutationCtx;
@@ -87,6 +110,66 @@ export const _getByStripeSubscriptionId = internalQuery({
         q.eq("stripeSubscriptionId", stripeSubscriptionId),
       )
       .unique();
+  },
+});
+
+// ─── Admin / debug helpers (internal-only) ─────────────────────────────────
+
+/**
+ * Inspect auth state for a given email — used during PR 1 testing to find
+ * orphaned authAccounts left over from earlier deploys with stricter schema
+ * validation. Safe to keep around: internal-only, read-only.
+ */
+export const _inspectAuthState = internalQuery({
+  args: { email: v.string() },
+  handler: async (ctx, { email }) => {
+    const users = await ctx.db
+      .query("users")
+      .withIndex("email", (q) => q.eq("email", email))
+      .collect();
+
+    // authAccounts has no by_email index so we scan and filter (small table during dev)
+    const allAccounts = await ctx.db.query("authAccounts").take(500);
+    const matching = allAccounts.filter(
+      (a) => (a as any).providerAccountId === email,
+    );
+
+    return {
+      userCount: users.length,
+      users: users.map((u) => ({
+        _id: u._id,
+        email: u.email,
+        name: u.name,
+        plan: (u as any).plan ?? null,
+        emailVerificationTime: u.emailVerificationTime ?? null,
+      })),
+      authAccountCount: matching.length,
+      authAccounts: matching.map((a) => ({
+        _id: a._id,
+        provider: (a as any).provider,
+        providerAccountId: (a as any).providerAccountId,
+        userId: (a as any).userId,
+      })),
+    };
+  },
+});
+
+/**
+ * Delete a password authAccount for the given email — used to recover from
+ * orphan accounts so the user can re-sign-up. Does NOT delete the user row
+ * (so any Google-OAuth login for the same email keeps working). Internal-only.
+ */
+export const _deletePasswordAccount = internalMutation({
+  args: { email: v.string() },
+  handler: async (ctx, { email }) => {
+    const allAccounts = await ctx.db.query("authAccounts").take(500);
+    const targets = allAccounts.filter(
+      (a) =>
+        (a as any).provider === "password" &&
+        (a as any).providerAccountId === email,
+    );
+    for (const t of targets) await ctx.db.delete(t._id);
+    return { deleted: targets.length };
   },
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -173,6 +173,57 @@ export const _deletePasswordAccount = internalMutation({
   },
 });
 
+/**
+ * Delete duplicate user rows for a given email that have no auth accounts
+ * pointing at them. Created during PR 1 testing when the `email` index on
+ * users was briefly absent (after main wiped indexes mid-flight, before our
+ * branch redeployed). Without the index, the auth library couldn't dedupe
+ * by email and created multiple `users` rows for the same address.
+ *
+ * Safety: only deletes user rows that have ZERO authAccounts referencing
+ * them. The active user (with the password authAccount) is preserved.
+ * Also deletes any dangling authSessions / authRefreshTokens that point at
+ * the deleted users.
+ */
+export const _deleteOrphanUsers = internalMutation({
+  args: { email: v.string() },
+  handler: async (ctx, { email }) => {
+    const users = await ctx.db
+      .query("users")
+      .withIndex("email", (q) => q.eq("email", email))
+      .collect();
+    if (users.length <= 1) return { deletedUsers: 0, deletedSessions: 0 };
+
+    const allAccounts = await ctx.db.query("authAccounts").take(2000);
+    const allSessions = await ctx.db.query("authSessions").take(2000);
+    const allRefresh = await ctx.db.query("authRefreshTokens").take(2000);
+
+    let deletedUsers = 0;
+    let deletedSessions = 0;
+    for (const u of users) {
+      const hasAccounts = allAccounts.some(
+        (a) => (a as any).userId === u._id,
+      );
+      if (hasAccounts) continue; // keep — this is the live user
+      // Cascade: delete sessions + refresh tokens pointing at this user
+      const userSessions = allSessions.filter(
+        (s) => (s as any).userId === u._id,
+      );
+      for (const s of userSessions) {
+        const refresh = allRefresh.filter(
+          (r) => (r as any).sessionId === s._id,
+        );
+        for (const r of refresh) await ctx.db.delete(r._id);
+        await ctx.db.delete(s._id);
+        deletedSessions++;
+      }
+      await ctx.db.delete(u._id);
+      deletedUsers++;
+    }
+    return { deletedUsers, deletedSessions };
+  },
+});
+
 // ─── Internal billing-column mutation (webhook-only) ───────────────────────
 
 const billingPatchValidator = v.object({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,0 +1,128 @@
+import { v, ConvexError } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import {
+  query,
+  internalQuery,
+  internalMutation,
+  type QueryCtx,
+  type MutationCtx,
+} from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+
+// ─── Public queries ────────────────────────────────────────────────────────
+
+/**
+ * Returns the current user's row, scoped to the caller. Never accepts a
+ * userId arg — identity always comes from `getAuthUserId(ctx)`.
+ */
+export const currentUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return null;
+    return await ctx.db.get(userId);
+  },
+});
+
+// ─── Server-side helpers (not registered as functions) ─────────────────────
+
+type AnyDbCtx = QueryCtx | MutationCtx;
+
+/**
+ * Throws UNAUTHENTICATED if the caller is not signed in. Returns the user doc.
+ * Use inside any query/mutation that requires a user.
+ */
+export async function requireUser(ctx: AnyDbCtx): Promise<Doc<"users">> {
+  const userId = await getAuthUserId(ctx);
+  if (!userId) throw new ConvexError("UNAUTHENTICATED");
+  const user = await ctx.db.get(userId);
+  if (!user) throw new ConvexError("USER_MISSING");
+  return user;
+}
+
+/**
+ * Like `requireUser` but additionally requires the email is verified.
+ * Used to gate Stripe checkout — Google OAuth users are auto-verified.
+ */
+export async function requireVerifiedUser(
+  ctx: AnyDbCtx,
+): Promise<Doc<"users">> {
+  const user = await requireUser(ctx);
+  if (!user.emailVerificationTime) {
+    throw new ConvexError("EMAIL_NOT_VERIFIED");
+  }
+  return user;
+}
+
+// (Action-context variants will be added in PR 2 alongside `convex/stripe.ts`,
+// once the generated `internal.users._getUserById` reference exists.)
+
+// ─── Internal lookups (called from Stripe webhook in PR 2) ─────────────────
+
+export const _getUserById = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    return await ctx.db.get(userId);
+  },
+});
+
+export const _getByStripeCustomerId = internalQuery({
+  args: { stripeCustomerId: v.string() },
+  handler: async (ctx, { stripeCustomerId }) => {
+    return await ctx.db
+      .query("users")
+      .withIndex("by_stripeCustomerId", (q) =>
+        q.eq("stripeCustomerId", stripeCustomerId),
+      )
+      .unique();
+  },
+});
+
+export const _getByStripeSubscriptionId = internalQuery({
+  args: { stripeSubscriptionId: v.string() },
+  handler: async (ctx, { stripeSubscriptionId }) => {
+    return await ctx.db
+      .query("users")
+      .withIndex("by_stripeSubscriptionId", (q) =>
+        q.eq("stripeSubscriptionId", stripeSubscriptionId),
+      )
+      .unique();
+  },
+});
+
+// ─── Internal billing-column mutation (webhook-only) ───────────────────────
+
+const billingPatchValidator = v.object({
+  plan: v.optional(v.union(v.literal("free"), v.literal("pro"))),
+  stripeCustomerId: v.optional(v.string()),
+  stripeSubscriptionId: v.optional(v.string()),
+  stripeSubscriptionStatus: v.optional(
+    v.union(
+      v.literal("active"),
+      v.literal("trialing"),
+      v.literal("past_due"),
+      v.literal("canceled"),
+      v.literal("incomplete"),
+      v.literal("incomplete_expired"),
+      v.literal("unpaid"),
+      v.literal("paused"),
+    ),
+  ),
+  stripePriceId: v.optional(v.string()),
+  stripeCurrentPeriodEnd: v.optional(v.number()),
+  cancelAtPeriodEnd: v.optional(v.boolean()),
+});
+
+/**
+ * Patches billing-related columns on a user. Internal-only — never exposed
+ * to the client. The Stripe webhook is the only call site.
+ */
+export const _updateBillingColumns = internalMutation({
+  args: {
+    userId: v.id("users"),
+    patch: billingPatchValidator,
+  },
+  handler: async (ctx, { userId, patch }) => {
+    await ctx.db.patch(userId, patch);
+  },
+});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "bills-in-congress",
       "version": "0.2.0",
       "dependencies": {
+        "@auth/core": "0.37.0",
         "@convex-dev/aggregate": "^0.2.1",
+        "@convex-dev/auth": "0.0.91",
         "@radix-ui/react-dialog": "^1.1.4",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-progress": "^1.1.1",
         "@radix-ui/react-scroll-area": "^1.2.2",
@@ -31,6 +34,7 @@
         "react": "^19.0.0",
         "react-markdown": "^10.1.0",
         "recharts": "^2.15.0",
+        "resend": "6.12.2",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -60,6 +64,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@auth/core": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.0.tgz",
+      "integrity": "sha512-LybAgfFC5dta3Mu3al0UbnzMGVBpZRqLMvvXupQOfETtPNlL7rXgTO13EVRTCdvPqMQrVYjODUDvgVfQM1M3Qg==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.7.1",
+        "jose": "^5.9.3",
+        "oauth4webapi": "^3.0.0",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -76,6 +111,50 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "convex": "^1.24.8"
+      }
+    },
+    "node_modules/@convex-dev/auth": {
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@convex-dev/auth/-/auth-0.0.91.tgz",
+      "integrity": "sha512-wLD4hszo3IhhMkwPs6ozWf0cUauwmhOvjUVn0g//kC338n/jApOjeDYWKCrn/qYUkveyDsbag5zrY8mVzA09Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
+        "cookie": "^1.0.1",
+        "is-network-error": "^1.1.0",
+        "jose": "^5.2.2",
+        "jwt-decode": "^4.0.0",
+        "lucia": "^3.2.0",
+        "oauth4webapi": "^3.1.2",
+        "path-to-regexp": "^6.3.0",
+        "server-only": "^0.0.1"
+      },
+      "bin": {
+        "auth": "dist/bin.cjs"
+      },
+      "peerDependencies": {
+        "@auth/core": "^0.37.0",
+        "convex": "^1.17.0",
+        "react": "^18.2.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@convex-dev/auth/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1291,6 +1370,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -1496,6 +1615,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1596,6 +1744,64 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1767,6 +1973,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2169,6 +2406,12 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2190,6 +2433,12 @@
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -2813,6 +3062,15 @@
         }
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3197,6 +3455,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3492,6 +3756,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3522,11 +3798,29 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -3572,6 +3866,17 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lucia": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/lucia/-/lucia-3.2.2.tgz",
+      "integrity": "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA==",
+      "deprecated": "This package has been deprecated. Please see https://lucia-auth.com/lucia-v3/migrate.",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0"
       }
     },
     "node_modules/lucide-react": {
@@ -4809,6 +5114,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4858,6 +5172,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4893,6 +5213,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
     },
     "node_modules/postcss": {
       "version": "8.5.10",
@@ -5050,6 +5376,28 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -5064,6 +5412,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5353,6 +5707,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -5437,6 +5812,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/sharp": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -5504,6 +5885,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/stringify-entities": {
@@ -5593,6 +5984,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -5974,6 +6375,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "optimize-images": "tsx scripts/optimize-images.ts"
   },
   "dependencies": {
+    "@auth/core": "0.37.0",
     "@convex-dev/aggregate": "^0.2.1",
+    "@convex-dev/auth": "0.0.91",
     "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-progress": "^1.1.1",
     "@radix-ui/react-scroll-area": "^1.2.2",
@@ -33,6 +36,7 @@
     "react": "^19.0.0",
     "react-markdown": "^10.1.0",
     "recharts": "^2.15.0",
+    "resend": "6.12.2",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,31 +1,65 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from "next/server";
+import {
+  convexAuthNextjsMiddleware,
+  createRouteMatcher,
+  nextjsMiddlewareRedirect,
+} from "@convex-dev/auth/nextjs/server";
 
-export async function proxy(request: NextRequest) {
-  const response = NextResponse.next()
+// Next.js 16 calls this file "proxy.ts" (formerly middleware.ts).
+// We use @convex-dev/auth's middleware wrapper since it's the only way it can
+// proxy /api/auth/* to Convex AND refresh session tokens. The wrapper accepts
+// our custom handler, where we layer route protection + the existing CORS and
+// cache-control behavior previously in proxy.ts.
 
-  // Set CORS headers for API routes
-  if (request.nextUrl.pathname.startsWith('/api/')) {
-    response.headers.set('Access-Control-Allow-Origin', '*')
-    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-  }
+const isAuthPage = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
+const isProtectedRoute = createRouteMatcher(["/account(.*)"]);
 
-  // Add cache control for bills pages
-  if (
-    request.nextUrl.pathname.startsWith('/bills') &&
-    !request.nextUrl.pathname.includes('api')
-  ) {
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=3600, stale-while-revalidate=59'
-    )
-  }
+export default convexAuthNextjsMiddleware(
+  async (request, { convexAuth }) => {
+    const { pathname, search } = request.nextUrl;
 
-  return response
-}
+    // 1. Bounce authed users away from sign-in/sign-up
+    if (isAuthPage(request) && (await convexAuth.isAuthenticated())) {
+      return nextjsMiddlewareRedirect(request, "/account");
+    }
 
+    // 2. Gate /account/* behind auth
+    if (isProtectedRoute(request) && !(await convexAuth.isAuthenticated())) {
+      const next = encodeURIComponent(pathname + search);
+      return nextjsMiddlewareRedirect(request, `/sign-in?redirect=${next}`);
+    }
+
+    // 3. Default: proceed and apply existing CORS / cache headers
+    const response = NextResponse.next();
+
+    // CORS for /api/* — preserves prior behavior
+    if (pathname.startsWith("/api/")) {
+      response.headers.set("Access-Control-Allow-Origin", "*");
+      response.headers.set(
+        "Access-Control-Allow-Methods",
+        "GET, POST, PUT, DELETE, OPTIONS",
+      );
+      response.headers.set(
+        "Access-Control-Allow-Headers",
+        "Content-Type, Authorization",
+      );
+    }
+
+    // Cache headers for /bills page routes — preserves prior behavior
+    if (pathname.startsWith("/bills") && !pathname.includes("api")) {
+      response.headers.set(
+        "Cache-Control",
+        "public, s-maxage=3600, stale-while-revalidate=59",
+      );
+    }
+
+    return response;
+  },
+  { cookieConfig: { maxAge: 60 * 60 * 24 * 30 } }, // 30-day sessions
+);
+
+// The matcher includes /api/* so /api/auth/* requests reach the proxy and get
+// forwarded to Convex. Files with extensions and _next are excluded.
 export const config = {
-  matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-  ],
-}
+  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+};


### PR DESCRIPTION
## Summary

Adds the authentication and email-verification infrastructure for the upcoming Free vs Pro membership model. Stripe billing is intentionally **not** included — that's PR 2. This PR keeps every existing public flow working (anonymous bill chat, all bills queries) and adds:

- Google OAuth + email/password sign-up via `@convex-dev/auth`
- Email verification via Resend, sending from a verified subdomain (`mail.billsincongress.com`)
- `/sign-in`, `/sign-up`, `/account`, `/forgot-password` pages
- User menu in the navigation
- Schema additions for `users`, `authAccounts`, `authSessions`, `authRefreshTokens`, `authVerificationCodes`, `authVerifiers`, `authRateLimits`, `stripeEvents` (PR 2 hook), `usageEvents` (forward-compat for Pro features), plus optional `userId` on `billChats`
- `proxy.ts` (Next.js 16's renamed middleware) carrying both auth route protection and the existing CORS/cache headers
- Forward-compat helpers (`requireUser`, `requireVerifiedUser`) and admin debug helpers (`_inspectAuthState`, `_deleteOrphanUsers`, `_deletePasswordAccount`)

## Edge cases handled
- **Email already registered**: pre-checks via `users.isEmailRegistered` before calling signUp; renders an inline alert with **Sign in instead** + **I have a verification code** + **Forgot password?** CTAs (each pre-fills the email)
- **Wrong password on sign-in**: vague "Invalid email or password" (no email enumeration)
- **Stuck OTP**: `Resend` from a verified subdomain with DKIM + SPF + DMARC records (added via Vercel CLI: `_dmarc`, `send.mail` MX, `send.mail` TXT, `resend._domainkey.mail` TXT)
- **Open redirect**: `callbacks.redirect` allow-list — only `billsincongress.com`/`www.billsincongress.com` over HTTPS or `localhost:3000`/`127.0.0.1:3000` over HTTP for dev
- **Password leak via failed-hydration GET form submit**: every auth form is `method="post"` so the password can't end up in the URL
- **Cache Components compatibility (Next.js 16)**: `ConvexAuthNextjsServerProvider` is wrapped in `<Suspense>` in the root layout (cookie reads are dynamic); `UserMenu` defers to client mount so its `useConvexAuth()` doesn't crash prerender
- **Dev console noise**: expected auth failures use `console.warn` so the Next.js dev overlay doesn't pop on every wrong password

## Production-side state set up out-of-band (no code, just record-keeping)
- Convex prod (`industrious-llama-331`) env: `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_RESEND_KEY`, `AUTH_EMAIL_FROM=Bills.Congress <hi@mail.billsincongress.com>`, `JWT_PRIVATE_KEY`, `JWKS`, `SITE_URL=https://billsincongress.com`
- Google OAuth client created with redirect URI `https://industrious-llama-331.convex.site/api/auth/callback/google`
- Resend domain `mail.billsincongress.com` verified (DKIM + SPF + DMARC); the apex `billsincongress.com` carries the DMARC TXT
- Convex deploy from this branch already ran — schema indexes are fully restored after the earlier main-deploy regression that wiped them (16 auth/Stripe indexes back; the new `congressChamberBreakdowns` index from main is also present and was repopulated via `congressApi:triggerRecomputeStats`)
- Cleaned up 2 orphan `users` rows that accumulated during the index-wiped window (kept the active user with the password authAccount intact)

## Open follow-ups (intentionally out of scope)
- **PR 2 — Stripe billing**: pricing page, checkout/portal sessions, webhook with idempotency + customer-lookup fallback, `requirePro` gate. Plan already drafted at `~/.claude/plans/i-want-you-to-humming-thunder.md`.
- **Real password-reset UI**: `/forgot-password` is currently a placeholder pointing to email support. The Resend OTP password-reset provider is wired in `convex/auth.ts`; just needs the matching UI.
- **Server-side `preloadQuery` for auth-aware pages**: when we add a server-rendered route that needs the user's auth state inline, scope `ConvexAuthNextjsServerProvider` more narrowly than the root.

## Test plan
- [x] `npm run build` — 112/112 pages prerender, no TypeScript errors
- [x] Google OAuth — verified end-to-end (signed in, viewed `/account` showing name + Free plan + Verified badge)
- [x] Email + password sign-up + OTP verification — verified end-to-end (code arrived from `hi@mail.billsincongress.com`, verified, signed in)
- [x] Anonymous bill chat — regression-tested in incognito on `/bills/[id]`
- [x] Live site (`billsincongress.com`) — TTFB ~150ms, cache HIT, SSR data inline (`partyCounts`, `totalCount`)
- [x] Convex prod — all auth functions live (`users:currentUser`, `users:isEmailRegistered`, `auth:signIn`, `/api/auth/*` HTTP routes), all 16 auth indexes + `congressChamberBreakdowns.by_congress_and_chamber` rebuilt
- [ ] Reviewer: spot-check `/sign-in`, `/sign-up`, `/account`, `/forgot-password` rendering; confirm UserMenu appears post-hydration and signs out cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)