### PR TITLE
feat(chat): daily rate limits — 5/day anonymous, 100/day logged-in

### DIFF
--- a/components/bills/bill-qa.tsx
+++ b/components/bills/bill-qa.tsx
@@ -1,10 +1,21 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+import { useQuery } from 'convex/react';
 import { billsService } from '@/lib/services/bills-service';
 import ReactMarkdown from 'react-markdown';
 import { ArrowUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useConvexEnabled } from '@/app/ConvexClientProvider';
+import { api } from '@/convex/_generated/api';
+import { RateLimitDialog } from '@/components/bills/rate-limit-dialog';
+
+interface RateLimitInfo {
+  kind: 'anonymous' | 'authed';
+  max: number;
+  resetAt: number;
+}
 
 interface Message {
   id: string;
@@ -83,9 +94,22 @@ export default function BillQA({ billId }: BillQAProps) {
   const [isLoadingHistory, setIsLoadingHistory] = useState(true);
   const [error, setError] = useState('');
   const [sessionId, setSessionId] = useState('');
+  const [rateLimitInfo, setRateLimitInfo] = useState<RateLimitInfo | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reactive read of "are you currently blocked?" state. Used to disable the
+  // input on initial render so a refresh after hitting the limit doesn't
+  // forget the state. Skipped (passes "skip") until we have a sessionId so
+  // we don't fire a query with an empty key.
+  const convexEnabled = useConvexEnabled();
+  const usage = useQuery(
+    api.rateLimits.getChatUsage,
+    convexEnabled && sessionId ? { sessionId } : 'skip',
+  );
+  const pathname = usePathname();
 
   useEffect(() => {
     const sid = getOrCreateSessionId();
@@ -119,7 +143,15 @@ export default function BillQA({ billId }: BillQAProps) {
 
       try {
         const result = await billsService.sendChatMessage(billId, sessionId, q);
-        if (result.error) {
+        if (result.error === 'RATE_LIMITED' && result.rateLimit) {
+          setMessages((prev) => prev.filter((m) => m.id !== tempId));
+          setRateLimitInfo({
+            kind: result.rateLimit.kind,
+            max: result.rateLimit.max,
+            resetAt: result.rateLimit.resetAt,
+          });
+          setDialogOpen(true);
+        } else if (result.error) {
           setError(result.error);
           setMessages((prev) => prev.filter((m) => m.id !== tempId));
         } else {
@@ -141,6 +173,25 @@ export default function BillQA({ billId }: BillQAProps) {
 
   const isEmpty = messages.length === 0 && !isLoadingHistory;
   const questionCount = messages.filter((m) => m.role === 'user').length;
+
+  // Persistent blocked state — survives refresh while the user is at zero
+  // remaining. The query returns `blocked: true` when the rate limiter
+  // refuses any further consumption.
+  const blocked = usage?.blocked === true;
+  const inputDisabled = isLoading || isLoadingHistory || blocked;
+  const blockedHint = blocked
+    ? `Daily limit reached. Resets at ${new Date(usage!.resetAt!).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}.`
+    : '';
+
+  function openLimitDialog() {
+    if (!usage || !usage.blocked || !usage.resetAt) return;
+    setRateLimitInfo({
+      kind: usage.kind,
+      max: usage.max,
+      resetAt: usage.resetAt,
+    });
+    setDialogOpen(true);
+  }
 
   return (
     <div className="rounded-sm border border-border bg-background flex flex-col overflow-hidden" style={{ height: '540px' }}>
@@ -230,10 +281,23 @@ export default function BillQA({ billId }: BillQAProps) {
         <div ref={messagesEndRef} />
       </div>
 
-      <div className="border-t border-border px-5 py-3 shrink-0">
+      <div className="border-t border-border px-5 py-3 shrink-0 space-y-2">
+        {blocked && (
+          <button
+            type="button"
+            onClick={openLimitDialog}
+            className="w-full text-left text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {blockedHint} <span className="underline underline-offset-2">See options →</span>
+          </button>
+        )}
         <form
           onSubmit={(e) => {
             e.preventDefault();
+            if (blocked) {
+              openLimitDialog();
+              return;
+            }
             handleSubmit(input);
           }}
           className="flex items-center gap-2"
@@ -243,14 +307,20 @@ export default function BillQA({ billId }: BillQAProps) {
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder={isEmpty ? 'Ask a question…' : 'Ask a follow-up…'}
-            className="flex-1 h-10 px-3 text-sm rounded-sm border border-border bg-background text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:border-foreground"
-            disabled={isLoading || isLoadingHistory}
+            placeholder={
+              blocked
+                ? 'Daily limit reached'
+                : isEmpty
+                  ? 'Ask a question…'
+                  : 'Ask a follow-up…'
+            }
+            className="flex-1 h-10 px-3 text-sm rounded-sm border border-border bg-background text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:border-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={inputDisabled}
             maxLength={500}
           />
           <button
             type="submit"
-            disabled={isLoading || isLoadingHistory || !input.trim()}
+            disabled={inputDisabled || !input.trim()}
             aria-label="Send"
             className="inline-flex h-10 w-10 items-center justify-center rounded-sm bg-foreground text-background hover:bg-foreground/85 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
           >
@@ -262,6 +332,17 @@ export default function BillQA({ billId }: BillQAProps) {
           </button>
         </form>
       </div>
+
+      {rateLimitInfo && (
+        <RateLimitDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          kind={rateLimitInfo.kind}
+          max={rateLimitInfo.max}
+          resetAt={rateLimitInfo.resetAt}
+          redirectTo={pathname}
+        />
+      )}
     </div>
   );
 }

--- a/components/bills/rate-limit-dialog.tsx
+++ b/components/bills/rate-limit-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface RateLimitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kind: "anonymous" | "authed";
+  max: number;
+  resetAt: number;
+  /** Where to redirect after sign-in / sign-up. Defaults to current URL. */
+  redirectTo?: string;
+}
+
+function formatResetTime(resetAtMs: number): string {
+  const date = new Date(resetAtMs);
+  const now = new Date();
+
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return sameDay ? time : `${date.toLocaleDateString()} at ${time}`;
+}
+
+export function RateLimitDialog({
+  open,
+  onOpenChange,
+  kind,
+  max,
+  resetAt,
+  redirectTo,
+}: RateLimitDialogProps) {
+  const resetLabel = formatResetTime(resetAt);
+  const signUpHref = `/sign-up${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`;
+  const signInHref = `/sign-in${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`;
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/70 backdrop-blur-sm",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed left-[50%] top-[50%] z-50 w-[92%] max-w-md translate-x-[-50%] translate-y-[-50%]",
+            "rounded-md border border-border bg-background p-6 shadow-lg",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          )}
+        >
+          <DialogPrimitive.Close
+            aria-label="Close"
+            className="absolute right-3 top-3 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="h-4 w-4" />
+          </DialogPrimitive.Close>
+
+          {kind === "anonymous" ? (
+            <>
+              <DialogPrimitive.Title className="font-serif text-2xl font-semibold tracking-tight">
+                You&apos;ve hit the free daily limit
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                Anonymous browsers can ask up to <span className="font-medium text-foreground">{max} questions a day</span>.{" "}
+                Create a free account and ask up to <span className="font-medium text-foreground">100 a day</span>.
+              </DialogPrimitive.Description>
+
+              <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+                <Button asChild className="w-full sm:flex-1">
+                  <Link href={signUpHref}>Sign up free</Link>
+                </Button>
+                <Button asChild variant="outline" className="w-full sm:flex-1">
+                  <Link href={signInHref}>I have an account</Link>
+                </Button>
+              </div>
+
+              <p className="mt-4 text-xs text-muted-foreground">
+                Or come back after <span className="font-medium text-foreground">{resetLabel}</span> when your daily quota resets.
+              </p>
+            </>
+          ) : (
+            <>
+              <DialogPrimitive.Title className="font-serif text-2xl font-semibold tracking-tight">
+                Daily chat limit reached
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                You&apos;ve asked the maximum of <span className="font-medium text-foreground">{max} questions</span> today. Your quota resets at{" "}
+                <span className="font-medium text-foreground">{resetLabel}</span>.
+              </DialogPrimitive.Description>
+
+              <div className="mt-5">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Got it
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as functions from "../functions.js";
 import type * as http from "../http.js";
 import type * as llm from "../llm.js";
 import type * as mutations from "../mutations.js";
+import type * as rateLimits from "../rateLimits.js";
 import type * as sync from "../sync.js";
 import type * as users from "../users.js";
 
@@ -42,6 +43,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   llm: typeof llm;
   mutations: typeof mutations;
+  rateLimits: typeof rateLimits;
   sync: typeof sync;
   users: typeof users;
 }>;
@@ -75,4 +77,5 @@ export declare const internal: FilterApi<
 export declare const components: {
   billsByChamber: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"billsByChamber">;
   billsByStage: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"billsByStage">;
+  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
 };

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,5 +1,6 @@
 import { defineApp } from "convex/server";
 import aggregate from "@convex-dev/aggregate/convex.config.js";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config.js";
 
 const app = defineApp();
 
@@ -11,5 +12,8 @@ app.use(aggregate, { name: "billsByChamber" });
 // Aggregate of bills keyed by [progressStage] within each congress namespace.
 // Used to compute the per-stage breakdown for the homepage status chart.
 app.use(aggregate, { name: "billsByStage" });
+
+// Application-level rate limits (chat quotas — see convex/rateLimits.ts).
+app.use(rateLimiter);
 
 export default app;

--- a/convex/llm.ts
+++ b/convex/llm.ts
@@ -1,6 +1,8 @@
 import { action, internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { internal, api } from "./_generated/api";
 import { v } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { rateLimiter } from "./rateLimits";
 
 const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const MODEL = "groq/compound-mini";
@@ -174,12 +176,51 @@ export const sendChatMessage = action({
     sessionId: v.string(),
     question: v.string(),
   },
-  handler: async (ctx, args): Promise<{ answer: string; error?: string }> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    answer: string;
+    error?: string;
+    rateLimit?: {
+      kind: "anonymous" | "authed";
+      max: number;
+      retryAfterMs: number;
+      resetAt: number;
+    };
+  }> => {
     const { billId, sessionId, question } = args;
 
     const apiKey = process.env.GROQ_API_KEY;
     if (!apiKey) {
       return { answer: "", error: "Groq API key not configured." };
+    }
+
+    // Daily quota check (PR 2). Anonymous browsers get 5/day keyed by
+    // sessionId; logged-in users get 100/day keyed by userId. Reset at
+    // midnight US Eastern (EST baseline) per `start: 5h` in rateLimits.ts.
+    // We consume the token BEFORE calling Groq. If Groq fails after, the
+    // user "loses" that question — small leak, easy reasoning. Acceptable
+    // first-cut trade-off; revisit if Groq error rate gets noticeable.
+    const userId = await getAuthUserId(ctx);
+    const isAuthed = userId !== null;
+    const limitName = isAuthed ? "chatAuthedPerDay" : "chatAnonPerDay";
+    const limitKey = isAuthed ? userId! : sessionId;
+    const limitMax = isAuthed ? 100 : 5;
+    const limitStatus = await rateLimiter.limit(ctx, limitName, {
+      key: limitKey,
+    });
+    if (!limitStatus.ok) {
+      return {
+        answer: "",
+        error: "RATE_LIMITED",
+        rateLimit: {
+          kind: isAuthed ? "authed" : "anonymous",
+          max: limitMax,
+          retryAfterMs: limitStatus.retryAfter ?? 0,
+          resetAt: Date.now() + (limitStatus.retryAfter ?? 0),
+        },
+      };
     }
 
     try {

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -1,0 +1,64 @@
+import { v } from "convex/values";
+import { RateLimiter, HOUR, DAY } from "@convex-dev/rate-limiter";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { components } from "./_generated/api";
+import { query } from "./_generated/server";
+
+// ─── Limit definitions ─────────────────────────────────────────────────────
+// `start: 5 * HOUR` aligns the 24h fixed window to Unix-epoch + 5h, which is
+// midnight US Eastern (EST). During EDT (mid-March → early November) the
+// reset will land 1h later (1 AM ET) — the UI surfaces the actual reset time
+// so users always see something accurate. See plan file for the DST trade-off.
+//
+// `kind: "fixed window"` grants all tokens at once at the start of each
+// window; no token-bucket carry-over.
+export const rateLimiter = new RateLimiter(components.rateLimiter, {
+  // Anonymous browsers — keyed by browser sessionId
+  chatAnonPerDay: {
+    kind: "fixed window",
+    rate: 5,
+    period: DAY,
+    start: 5 * HOUR,
+  },
+  // Logged-in users — keyed by userId. Email-verification status is
+  // intentionally NOT a factor; that gate is reserved for the Pro upgrade
+  // (PR 3+).
+  chatAuthedPerDay: {
+    kind: "fixed window",
+    rate: 100,
+    period: DAY,
+    start: 5 * HOUR,
+  },
+});
+
+// ─── Public query: current chat quota status ───────────────────────────────
+// The chat UI calls this only AFTER hitting RATE_LIMITED (to render the
+// dialog with up-to-the-second reset time) and on initial load (so a
+// disabled state survives a refresh). It never consumes a token.
+//
+// We don't expose a remaining-count number here on purpose — the chosen UX
+// only shows anything when the user is already blocked, so we just need
+// (a) "are you blocked?" and (b) "when does it reset?".
+export const getChatUsage = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, { sessionId }) => {
+    const userId = await getAuthUserId(ctx);
+    const isAuthed = userId !== null;
+    const limitName = isAuthed ? "chatAuthedPerDay" : "chatAnonPerDay";
+    const max = isAuthed ? 100 : 5;
+    const key = isAuthed ? userId! : sessionId;
+
+    const status = await rateLimiter.check(ctx, limitName, { key });
+    const blocked = !status.ok;
+    const resetAt = blocked
+      ? Date.now() + (status.retryAfter ?? 0)
+      : null;
+
+    return {
+      kind: isAuthed ? ("authed" as const) : ("anonymous" as const),
+      max,
+      blocked,
+      resetAt,
+    };
+  },
+});

--- a/lib/services/bills-service.ts
+++ b/lib/services/bills-service.ts
@@ -274,12 +274,16 @@ export const billsService = {
   /**
    * Send a message in the bill chat and return the AI response.
    * Persists both the user message and the assistant reply in Convex.
+   *
+   * On rate-limit hit, returns `error: "RATE_LIMITED"` with a `rateLimit`
+   * object describing the cap and reset time. Caller (bill-qa.tsx) is
+   * expected to render a dialog from those fields.
    */
   async sendChatMessage(
     billId: string,
     sessionId: string,
     question: string
-  ): Promise<{ answer: string; error?: string }> {
+  ): Promise<ChatResult> {
     const client = getConvexClient();
     if (!client) {
       return { answer: "", error: "Service not available" };
@@ -287,10 +291,31 @@ export const billsService = {
 
     try {
       const { api } = await import('../../convex/_generated/api');
-      return await client.action(api.llm.sendChatMessage, { billId, sessionId, question });
+      const result = await client.action(api.llm.sendChatMessage, {
+        billId,
+        sessionId,
+        question,
+      });
+      return result as ChatResult;
     } catch (error) {
       console.error('Error sending chat message:', error);
       return { answer: "", error: "Failed to get response" };
     }
   },
+};
+
+/**
+ * Return type for the bill chat. The `RATE_LIMITED` branch carries enough
+ * info for the UI to render a "you've hit your daily limit" dialog with
+ * the right copy + reset time, without a second round-trip.
+ */
+export type ChatResult = {
+  answer: string;
+  error?: string;
+  rateLimit?: {
+    kind: "anonymous" | "authed";
+    max: number;
+    retryAfterMs: number;
+    resetAt: number;
+  };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@auth/core": "0.37.0",
         "@convex-dev/aggregate": "^0.2.1",
         "@convex-dev/auth": "0.0.91",
+        "@convex-dev/rate-limiter": "0.3.2",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "2.1.16",
         "@radix-ui/react-label": "^2.1.1",
@@ -155,6 +156,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@convex-dev/rate-limiter": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/rate-limiter/-/rate-limiter-0.3.2.tgz",
+      "integrity": "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.24.8",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@auth/core": "0.37.0",
     "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/auth": "0.0.91",
+    "@convex-dev/rate-limiter": "0.3.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-label": "^2.1.1",


### PR DESCRIPTION
## Summary

Adds a per-day quota on the bill chat feature to (a) cap Groq cost from anonymous abuse and (b) give a clean non-paywall reason to create an account before Stripe lands.

| Tier | Limit | Key | Reset |
|---|---|---|---|
| Anonymous browser | 5 questions/day | browser `sessionId` | midnight US Eastern (EST baseline) |
| Logged-in (any account) | 100 questions/day | `userId` | midnight US Eastern (EST baseline) |

Email-verification status is intentionally NOT a factor for chat — that gate is reserved for the Pro upgrade in a future PR. Stripe is deferred.

## Why this shape

- **`@convex-dev/rate-limiter`** Convex Component — same publisher as our existing `@convex-dev/auth` and `@convex-dev/aggregate`. Single-file install via `convex.config.ts`. Atomic, fail-closed, no extra schema.
- **Fixed window with `start: 5 * HOUR`** aligns the 24h windows to midnight EST. During EDT (mid-March → early November), the wall-clock reset shifts to 1 AM ET — the UI surfaces the actual reset time pulled from the rate-limiter, so users always see something accurate. Per-user-timezone reset adds complexity for marginal benefit; documented as a deferred enhancement.
- **UX: dialog-only on hit.** No always-visible counter. Chat works exactly as today until a user hits zero, then a Radix dialog opens. Anonymous variant has prominent **Sign up free** + **I have an account** CTAs (both preserve the redirect back to the current bill). Authed variant is a clean "resets at X" message.
- **Persistent disabled state** via `getChatUsage` query — if a user refreshes after hitting zero, the input stays disabled with a "Daily limit reached. Resets at X — See options →" hint that re-opens the dialog.

## What changed

| Path | Change |
|---|---|
| [convex/convex.config.ts](convex/convex.config.ts) | `app.use(rateLimiter)` next to existing aggregate registrations |
| [convex/rateLimits.ts](convex/rateLimits.ts) | **New.** Two named limits + `getChatUsage` query (read-only, no token consumption) |
| [convex/llm.ts](convex/llm.ts) | `sendChatMessage` consumes a token before Groq; new `RATE_LIMITED` return shape |
| [lib/services/bills-service.ts](lib/services/bills-service.ts) | Widened `ChatResult` type with optional `rateLimit` payload |
| [components/bills/rate-limit-dialog.tsx](components/bills/rate-limit-dialog.tsx) | **New.** Radix dialog with anonymous + authed variants |
| [components/bills/bill-qa.tsx](components/bills/bill-qa.tsx) | Opens dialog on `RATE_LIMITED`, disables input persistently when reactive `getChatUsage` reports `blocked: true` |
| [package.json](package.json) | Pinned `@convex-dev/rate-limiter@0.3.2` |

## Tradeoffs explicitly accepted (out of scope)
- **Token leak on Groq failure.** If Groq errors *after* token consumption, that question is "lost" for the user. Acceptable trade for transactional simplicity. Worth a small UX polish later (auto-credit one back on Groq error). Not in this PR.
- **Anonymous limit can be circumvented** by clearing localStorage. Unavoidable without IP tracking, which has its own privacy cost. Acceptable.
- **DST drift** of 1 hour twice a year. UI shows accurate reset time so users don't get surprised.

## Test plan

### Anonymous (test in incognito)
- [ ] Open `/bills/<id>`, ask 5 questions. Each succeeds normally.
- [ ] Ask a 6th — dialog opens. Heading reads "free daily limit", primary CTA is **Sign up free**, secondary is **I have an account**, footer shows reset time.
- [ ] Click **Sign up free** → lands at `/sign-up?redirect=/bills/<id>`. Complete sign-up + verify → return to bill, dialog gone, can ask freely (now 100/day).
- [ ] Refresh the original incognito tab without signing up → input is disabled with "Daily limit reached. Resets at <time> — See options →" hint that re-opens the dialog.

### Logged-in
- [ ] Signed in. Send one question normally. (No counter visible by design.)
- [ ] In Convex dashboard, manually advance the rate-limiter row for `chatAuthedPerDay:<userId>` to capacity (or wait until you hit 101) → dialog opens with the **authed** variant: no Sign up CTA, just reset-time + dismiss.

### Cross-state
- [ ] Anonymous user signs up mid-day after using 3/5 questions → on the new authed identity, get a fresh 100 (different key namespace).
- [ ] Two browsers, same logged-in account → quota is shared. 50 from A + 50 from B → 101st blocked from either.
- [ ] `npx convex deploy --dry-run` from this branch — confirmed: no existing indexes deleted, only the new component install.

## Build
- [x] `npm run build` — 112 routes prerender (Cache Components compatible)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx convex run rateLimits:getChatUsage '{"sessionId":"smoke"}'` returns `{ blocked: false, kind: "anonymous", max: 5, resetAt: null }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)