### PR TITLE
feat(auth): persistent 60-day sessions — stay signed in across browser restarts

### DIFF
--- a/components/bills/bill-qa.tsx
+++ b/components/bills/bill-qa.tsx
@@ -1,10 +1,21 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+import { useQuery } from 'convex/react';
 import { billsService } from '@/lib/services/bills-service';
 import ReactMarkdown from 'react-markdown';
 import { ArrowUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useConvexEnabled } from '@/app/ConvexClientProvider';
+import { api } from '@/convex/_generated/api';
+import { RateLimitDialog } from '@/components/bills/rate-limit-dialog';
+
+interface RateLimitInfo {
+  kind: 'anonymous' | 'authed';
+  max: number;
+  resetAt: number;
+}
 
 interface Message {
   id: string;
@@ -83,9 +94,22 @@ export default function BillQA({ billId }: BillQAProps) {
   const [isLoadingHistory, setIsLoadingHistory] = useState(true);
   const [error, setError] = useState('');
   const [sessionId, setSessionId] = useState('');
+  const [rateLimitInfo, setRateLimitInfo] = useState<RateLimitInfo | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reactive read of "are you currently blocked?" state. Used to disable the
+  // input on initial render so a refresh after hitting the limit doesn't
+  // forget the state. Skipped (passes "skip") until we have a sessionId so
+  // we don't fire a query with an empty key.
+  const convexEnabled = useConvexEnabled();
+  const usage = useQuery(
+    api.rateLimits.getChatUsage,
+    convexEnabled && sessionId ? { sessionId } : 'skip',
+  );
+  const pathname = usePathname();
 
   useEffect(() => {
     const sid = getOrCreateSessionId();
@@ -119,7 +143,15 @@ export default function BillQA({ billId }: BillQAProps) {
 
       try {
         const result = await billsService.sendChatMessage(billId, sessionId, q);
-        if (result.error) {
+        if (result.error === 'RATE_LIMITED' && result.rateLimit) {
+          setMessages((prev) => prev.filter((m) => m.id !== tempId));
+          setRateLimitInfo({
+            kind: result.rateLimit.kind,
+            max: result.rateLimit.max,
+            resetAt: result.rateLimit.resetAt,
+          });
+          setDialogOpen(true);
+        } else if (result.error) {
           setError(result.error);
           setMessages((prev) => prev.filter((m) => m.id !== tempId));
         } else {
@@ -141,6 +173,25 @@ export default function BillQA({ billId }: BillQAProps) {
 
   const isEmpty = messages.length === 0 && !isLoadingHistory;
   const questionCount = messages.filter((m) => m.role === 'user').length;
+
+  // Persistent blocked state — survives refresh while the user is at zero
+  // remaining. The query returns `blocked: true` when the rate limiter
+  // refuses any further consumption.
+  const blocked = usage?.blocked === true;
+  const inputDisabled = isLoading || isLoadingHistory || blocked;
+  const blockedHint = blocked
+    ? `Daily limit reached. Resets at ${new Date(usage!.resetAt!).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}.`
+    : '';
+
+  function openLimitDialog() {
+    if (!usage || !usage.blocked || !usage.resetAt) return;
+    setRateLimitInfo({
+      kind: usage.kind,
+      max: usage.max,
+      resetAt: usage.resetAt,
+    });
+    setDialogOpen(true);
+  }
 
   return (
     <div className="rounded-sm border border-border bg-background flex flex-col overflow-hidden" style={{ height: '540px' }}>
@@ -230,10 +281,23 @@ export default function BillQA({ billId }: BillQAProps) {
         <div ref={messagesEndRef} />
       </div>
 
-      <div className="border-t border-border px-5 py-3 shrink-0">
+      <div className="border-t border-border px-5 py-3 shrink-0 space-y-2">
+        {blocked && (
+          <button
+            type="button"
+            onClick={openLimitDialog}
+            className="w-full text-left text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {blockedHint} <span className="underline underline-offset-2">See options →</span>
+          </button>
+        )}
         <form
           onSubmit={(e) => {
             e.preventDefault();
+            if (blocked) {
+              openLimitDialog();
+              return;
+            }
             handleSubmit(input);
           }}
           className="flex items-center gap-2"
@@ -243,14 +307,20 @@ export default function BillQA({ billId }: BillQAProps) {
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder={isEmpty ? 'Ask a question…' : 'Ask a follow-up…'}
-            className="flex-1 h-10 px-3 text-sm rounded-sm border border-border bg-background text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:border-foreground"
-            disabled={isLoading || isLoadingHistory}
+            placeholder={
+              blocked
+                ? 'Daily limit reached'
+                : isEmpty
+                  ? 'Ask a question…'
+                  : 'Ask a follow-up…'
+            }
+            className="flex-1 h-10 px-3 text-sm rounded-sm border border-border bg-background text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:border-foreground disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={inputDisabled}
             maxLength={500}
           />
           <button
             type="submit"
-            disabled={isLoading || isLoadingHistory || !input.trim()}
+            disabled={inputDisabled || !input.trim()}
             aria-label="Send"
             className="inline-flex h-10 w-10 items-center justify-center rounded-sm bg-foreground text-background hover:bg-foreground/85 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
           >
@@ -262,6 +332,17 @@ export default function BillQA({ billId }: BillQAProps) {
           </button>
         </form>
       </div>
+
+      {rateLimitInfo && (
+        <RateLimitDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          kind={rateLimitInfo.kind}
+          max={rateLimitInfo.max}
+          resetAt={rateLimitInfo.resetAt}
+          redirectTo={pathname}
+        />
+      )}
     </div>
   );
 }

--- a/components/bills/rate-limit-dialog.tsx
+++ b/components/bills/rate-limit-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface RateLimitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kind: "anonymous" | "authed";
+  max: number;
+  resetAt: number;
+  /** Where to redirect after sign-in / sign-up. Defaults to current URL. */
+  redirectTo?: string;
+}
+
+function formatResetTime(resetAtMs: number): string {
+  const date = new Date(resetAtMs);
+  const now = new Date();
+
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return sameDay ? time : `${date.toLocaleDateString()} at ${time}`;
+}
+
+export function RateLimitDialog({
+  open,
+  onOpenChange,
+  kind,
+  max,
+  resetAt,
+  redirectTo,
+}: RateLimitDialogProps) {
+  const resetLabel = formatResetTime(resetAt);
+  const signUpHref = `/sign-up${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`;
+  const signInHref = `/sign-in${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`;
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/70 backdrop-blur-sm",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed left-[50%] top-[50%] z-50 w-[92%] max-w-md translate-x-[-50%] translate-y-[-50%]",
+            "rounded-md border border-border bg-background p-6 shadow-lg",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          )}
+        >
+          <DialogPrimitive.Close
+            aria-label="Close"
+            className="absolute right-3 top-3 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="h-4 w-4" />
+          </DialogPrimitive.Close>
+
+          {kind === "anonymous" ? (
+            <>
+              <DialogPrimitive.Title className="font-serif text-2xl font-semibold tracking-tight">
+                You&apos;ve hit the free daily limit
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                Anonymous browsers can ask up to <span className="font-medium text-foreground">{max} questions a day</span>.{" "}
+                Create a free account and ask up to <span className="font-medium text-foreground">100 a day</span>.
+              </DialogPrimitive.Description>
+
+              <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+                <Button asChild className="w-full sm:flex-1">
+                  <Link href={signUpHref}>Sign up free</Link>
+                </Button>
+                <Button asChild variant="outline" className="w-full sm:flex-1">
+                  <Link href={signInHref}>I have an account</Link>
+                </Button>
+              </div>
+
+              <p className="mt-4 text-xs text-muted-foreground">
+                Or come back after <span className="font-medium text-foreground">{resetLabel}</span> when your daily quota resets.
+              </p>
+            </>
+          ) : (
+            <>
+              <DialogPrimitive.Title className="font-serif text-2xl font-semibold tracking-tight">
+                Daily chat limit reached
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                You&apos;ve asked the maximum of <span className="font-medium text-foreground">{max} questions</span> today. Your quota resets at{" "}
+                <span className="font-medium text-foreground">{resetLabel}</span>.
+              </DialogPrimitive.Description>
+
+              <div className="mt-5">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Got it
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as functions from "../functions.js";
 import type * as http from "../http.js";
 import type * as llm from "../llm.js";
 import type * as mutations from "../mutations.js";
+import type * as rateLimits from "../rateLimits.js";
 import type * as sync from "../sync.js";
 import type * as users from "../users.js";
 
@@ -42,6 +43,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   llm: typeof llm;
   mutations: typeof mutations;
+  rateLimits: typeof rateLimits;
   sync: typeof sync;
   users: typeof users;
 }>;
@@ -75,4 +77,5 @@ export declare const internal: FilterApi<
 export declare const components: {
   billsByChamber: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"billsByChamber">;
   billsByStage: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"billsByStage">;
+  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
 };

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -5,6 +5,27 @@ import { ConvexError } from "convex/values";
 import { ResendOTP } from "./ResendOTP";
 import { ResendOTPPasswordReset } from "./ResendOTPPasswordReset";
 
+// ─── Session lifetime ──────────────────────────────────────────────────────
+// We want users to stay signed in for a long time across browser restarts —
+// "set it and forget it" UX, no surprise sign-outs. 60 days is the chosen
+// upper bound (longer than the industry default of 30, still reasonable for
+// a low-risk public bills tracker; banking-grade apps would pick 15 min, we
+// are explicitly the opposite).
+//
+// The library refreshes the JWT access token transparently every hour using
+// the long-lived refresh token, so the only thing the user sees is "still
+// signed in" until either:
+//   (a) 60 days pass with no requests at all (inactiveDurationMs), OR
+//   (b) 60 days pass since the original sign-in (totalDurationMs)
+// whichever fires first. Refresh-token rotation with a 10s reuse window is
+// already on by default — old tokens are invalidated on use.
+//
+// This MUST stay in sync with `cookieConfig.maxAge` in `proxy.ts`. The
+// cookie expiry ≥ refresh-token expiry, otherwise users get signed out
+// every time the cookie expires even though the server-side session is
+// still valid. We use the same constant in both places.
+const SESSION_DURATION_MS = 1000 * 60 * 60 * 24 * 60; // 60 days
+
 // Allow-list for OAuth `redirectTo`. The library defaults to "starts with
 // SITE_URL only" which blocks local dev (we test from http://localhost:3000
 // while SITE_URL is the prod site). We tightly restrict the dev allow-list:
@@ -48,6 +69,14 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
       },
     }),
   ],
+  session: {
+    // Total time a session can live before forced re-auth. Hard cap.
+    totalDurationMs: SESSION_DURATION_MS,
+    // Time without any request before the session expires. Practically the
+    // same as the total cap for our usage (active users won't go 60 days
+    // silent), but the library treats them as separate gates.
+    inactiveDurationMs: SESSION_DURATION_MS,
+  },
   callbacks: {
     async redirect({ redirectTo }) {
       // Relative paths are always safe — the library resolves them against SITE_URL.

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,5 +1,6 @@
 import { defineApp } from "convex/server";
 import aggregate from "@convex-dev/aggregate/convex.config.js";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config.js";
 
 const app = defineApp();
 
@@ -11,5 +12,8 @@ app.use(aggregate, { name: "billsByChamber" });
 // Aggregate of bills keyed by [progressStage] within each congress namespace.
 // Used to compute the per-stage breakdown for the homepage status chart.
 app.use(aggregate, { name: "billsByStage" });
+
+// Application-level rate limits (chat quotas — see convex/rateLimits.ts).
+app.use(rateLimiter);
 
 export default app;

--- a/convex/llm.ts
+++ b/convex/llm.ts
@@ -1,6 +1,8 @@
 import { action, internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { internal, api } from "./_generated/api";
 import { v } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { rateLimiter } from "./rateLimits";
 
 const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const MODEL = "groq/compound-mini";
@@ -174,12 +176,51 @@ export const sendChatMessage = action({
     sessionId: v.string(),
     question: v.string(),
   },
-  handler: async (ctx, args): Promise<{ answer: string; error?: string }> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    answer: string;
+    error?: string;
+    rateLimit?: {
+      kind: "anonymous" | "authed";
+      max: number;
+      retryAfterMs: number;
+      resetAt: number;
+    };
+  }> => {
     const { billId, sessionId, question } = args;
 
     const apiKey = process.env.GROQ_API_KEY;
     if (!apiKey) {
       return { answer: "", error: "Groq API key not configured." };
+    }
+
+    // Daily quota check (PR 2). Anonymous browsers get 5/day keyed by
+    // sessionId; logged-in users get 100/day keyed by userId. Reset at
+    // midnight US Eastern (EST baseline) per `start: 5h` in rateLimits.ts.
+    // We consume the token BEFORE calling Groq. If Groq fails after, the
+    // user "loses" that question — small leak, easy reasoning. Acceptable
+    // first-cut trade-off; revisit if Groq error rate gets noticeable.
+    const userId = await getAuthUserId(ctx);
+    const isAuthed = userId !== null;
+    const limitName = isAuthed ? "chatAuthedPerDay" : "chatAnonPerDay";
+    const limitKey = isAuthed ? userId! : sessionId;
+    const limitMax = isAuthed ? 100 : 5;
+    const limitStatus = await rateLimiter.limit(ctx, limitName, {
+      key: limitKey,
+    });
+    if (!limitStatus.ok) {
+      return {
+        answer: "",
+        error: "RATE_LIMITED",
+        rateLimit: {
+          kind: isAuthed ? "authed" : "anonymous",
+          max: limitMax,
+          retryAfterMs: limitStatus.retryAfter ?? 0,
+          resetAt: Date.now() + (limitStatus.retryAfter ?? 0),
+        },
+      };
     }
 
     try {

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -1,0 +1,64 @@
+import { v } from "convex/values";
+import { RateLimiter, HOUR, DAY } from "@convex-dev/rate-limiter";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { components } from "./_generated/api";
+import { query } from "./_generated/server";
+
+// ─── Limit definitions ─────────────────────────────────────────────────────
+// `start: 5 * HOUR` aligns the 24h fixed window to Unix-epoch + 5h, which is
+// midnight US Eastern (EST). During EDT (mid-March → early November) the
+// reset will land 1h later (1 AM ET) — the UI surfaces the actual reset time
+// so users always see something accurate. See plan file for the DST trade-off.
+//
+// `kind: "fixed window"` grants all tokens at once at the start of each
+// window; no token-bucket carry-over.
+export const rateLimiter = new RateLimiter(components.rateLimiter, {
+  // Anonymous browsers — keyed by browser sessionId
+  chatAnonPerDay: {
+    kind: "fixed window",
+    rate: 5,
+    period: DAY,
+    start: 5 * HOUR,
+  },
+  // Logged-in users — keyed by userId. Email-verification status is
+  // intentionally NOT a factor; that gate is reserved for the Pro upgrade
+  // (PR 3+).
+  chatAuthedPerDay: {
+    kind: "fixed window",
+    rate: 100,
+    period: DAY,
+    start: 5 * HOUR,
+  },
+});
+
+// ─── Public query: current chat quota status ───────────────────────────────
+// The chat UI calls this only AFTER hitting RATE_LIMITED (to render the
+// dialog with up-to-the-second reset time) and on initial load (so a
+// disabled state survives a refresh). It never consumes a token.
+//
+// We don't expose a remaining-count number here on purpose — the chosen UX
+// only shows anything when the user is already blocked, so we just need
+// (a) "are you blocked?" and (b) "when does it reset?".
+export const getChatUsage = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, { sessionId }) => {
+    const userId = await getAuthUserId(ctx);
+    const isAuthed = userId !== null;
+    const limitName = isAuthed ? "chatAuthedPerDay" : "chatAnonPerDay";
+    const max = isAuthed ? 100 : 5;
+    const key = isAuthed ? userId! : sessionId;
+
+    const status = await rateLimiter.check(ctx, limitName, { key });
+    const blocked = !status.ok;
+    const resetAt = blocked
+      ? Date.now() + (status.retryAfter ?? 0)
+      : null;
+
+    return {
+      kind: isAuthed ? ("authed" as const) : ("anonymous" as const),
+      max,
+      blocked,
+      resetAt,
+    };
+  },
+});

--- a/lib/services/bills-service.ts
+++ b/lib/services/bills-service.ts
@@ -274,12 +274,16 @@ export const billsService = {
   /**
    * Send a message in the bill chat and return the AI response.
    * Persists both the user message and the assistant reply in Convex.
+   *
+   * On rate-limit hit, returns `error: "RATE_LIMITED"` with a `rateLimit`
+   * object describing the cap and reset time. Caller (bill-qa.tsx) is
+   * expected to render a dialog from those fields.
    */
   async sendChatMessage(
     billId: string,
     sessionId: string,
     question: string
-  ): Promise<{ answer: string; error?: string }> {
+  ): Promise<ChatResult> {
     const client = getConvexClient();
     if (!client) {
       return { answer: "", error: "Service not available" };
@@ -287,10 +291,31 @@ export const billsService = {
 
     try {
       const { api } = await import('../../convex/_generated/api');
-      return await client.action(api.llm.sendChatMessage, { billId, sessionId, question });
+      const result = await client.action(api.llm.sendChatMessage, {
+        billId,
+        sessionId,
+        question,
+      });
+      return result as ChatResult;
     } catch (error) {
       console.error('Error sending chat message:', error);
       return { answer: "", error: "Failed to get response" };
     }
   },
+};
+
+/**
+ * Return type for the bill chat. The `RATE_LIMITED` branch carries enough
+ * info for the UI to render a "you've hit your daily limit" dialog with
+ * the right copy + reset time, without a second round-trip.
+ */
+export type ChatResult = {
+  answer: string;
+  error?: string;
+  rateLimit?: {
+    kind: "anonymous" | "authed";
+    max: number;
+    retryAfterMs: number;
+    resetAt: number;
+  };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@auth/core": "0.37.0",
         "@convex-dev/aggregate": "^0.2.1",
         "@convex-dev/auth": "0.0.91",
+        "@convex-dev/rate-limiter": "0.3.2",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "2.1.16",
         "@radix-ui/react-label": "^2.1.1",
@@ -155,6 +156,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@convex-dev/rate-limiter": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/rate-limiter/-/rate-limiter-0.3.2.tgz",
+      "integrity": "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.24.8",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@auth/core": "0.37.0",
     "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/auth": "0.0.91",
+    "@convex-dev/rate-limiter": "0.3.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-label": "^2.1.1",

--- a/proxy.ts
+++ b/proxy.ts
@@ -11,6 +11,24 @@ import {
 // our custom handler, where we layer route protection + the existing CORS and
 // cache-control behavior previously in proxy.ts.
 
+// Cookie / session lifetime. MUST match `SESSION_DURATION_MS` in
+// `convex/auth.ts`. The cookie's maxAge needs to be ≥ the refresh-token's
+// `inactiveDurationMs`, otherwise the browser drops the cookie before the
+// server-side session expires and the user is signed out for no good reason.
+//
+// Cookie attributes set by `@convex-dev/auth/nextjs/server` (verified in lib
+// source `dist/nextjs/server/cookies.js`):
+//   - httpOnly: true   (XSS-safe — JS can't read tokens)
+//   - sameSite: lax    (CSRF-safe, still works across OAuth redirects)
+//   - secure:   true on prod, false on localhost
+//   - path:     /
+//   - prefix:   __Host- on prod (pins cookie to exact host, no subdomains)
+//
+// Three cookies are set: __Host-__convexAuthJWT (1h access token, rotates
+// transparently), __Host-__convexAuthRefreshToken (60d, used to mint new
+// access tokens), __Host-__convexAuthOAuthVerifier (short-lived, OAuth flow).
+const SESSION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 60; // 60 days
+
 const isAuthPage = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
 const isProtectedRoute = createRouteMatcher(["/account(.*)"]);
 
@@ -55,7 +73,7 @@ export default convexAuthNextjsMiddleware(
 
     return response;
   },
-  { cookieConfig: { maxAge: 60 * 60 * 24 * 30 } }, // 30-day sessions
+  { cookieConfig: { maxAge: SESSION_COOKIE_MAX_AGE_SECONDS } },
 );
 
 // The matcher includes /api/* so /api/auth/* requests reach the proxy and get


### PR DESCRIPTION
## Summary

Make session persistence robust, well-documented, and longer-than-default. Users sign in once and stay signed in for 60 days across browser closes/reopens — the "set it and forget it" UX expected on every modern consumer site.

**Stacked on top of PR #38** (rate limits) since both are bottom-of-the-funnel UX improvements; cherry-picked the rate-limit commit so this branch is also self-deployable. When #38 merges, this PR's diff against main will be just the session changes.

## Audit findings (current setup is *mostly* correct)

The library `@convex-dev/auth` already gives us 30-day persistent sessions out of the box, with secure cookie defaults verified directly from its source (`node_modules/@convex-dev/auth/dist/nextjs/server/cookies.js`):

| Cookie attribute | Value | Source |
|---|---|---|
| `httpOnly` | `true` | lib default — XSS-safe |
| `sameSite` | `lax` | lib default — CSRF-safe + OAuth-friendly |
| `secure` | `true` (auto-`false` on `localhost`) | lib default |
| `path` | `/` | lib default |
| Name prefix | `__Host-` on prod | lib default — pins cookie to exact host |
| `maxAge` | 30 days | our setting in `proxy.ts` (was) |

Three cookies are written: `__Host-__convexAuthJWT` (1 h access token, rotates transparently), `__Host-__convexAuthRefreshToken` (used to mint new access tokens), `__Host-__convexAuthOAuthVerifier` (short-lived, OAuth flow only).

**Refresh-token rotation with replay detection** (10s reuse window) is on by default in the library — nothing to configure. Old refresh tokens are invalidated on use; reuse outside the window invalidates all descendants.

## What this PR changes

1. **Bumps both server session lifetime and cookie maxAge to 60 days.** `convex/auth.ts` now passes an explicit `session: { totalDurationMs, inactiveDurationMs }`. `proxy.ts` matches with `cookieConfig: { maxAge }`. Single named constant in each file.
2. **Calls out the must-stay-in-sync invariant** in comments: cookie maxAge ≥ refresh-token inactiveDurationMs. If they drift, browsers drop the cookie while the server session is still alive → user gets surprise sign-outs.
3. **Documents the full cookie attribute set** in `proxy.ts` with the lib-source reference, so anyone touching auth knows exactly what's being applied without re-reading library internals.

## Cross-domain pitfall — already handled

`__Host-` cookies are pinned to the exact host they were set on. If a user signed in on `billsincongress.com` and then typed `www.billsincongress.com`, they'd be logged out on the www subdomain.

✅ Verified: Vercel already 307-redirects `www → apex` at the edge:
```
$ curl -sI https://www.billsincongress.com | head -5
HTTP/2 307
location: https://billsincongress.com/
```
Users only ever interact with the apex, so the `__Host-` pinning is correct. No code change needed.

## Files

| Path | Change |
|---|---|
| [convex/auth.ts](convex/auth.ts) | Adds `session` config + `SESSION_DURATION_MS` constant + comment block explaining lifetime semantics |
| [proxy.ts](proxy.ts) | Renames `60 * 60 * 24 * 30` → `SESSION_COOKIE_MAX_AGE_SECONDS`, bumps to 60 days, adds documentation block |

(Also includes the rate-limit commit from PR #38 as a base — that's PR #38's contents, not new in this PR.)

## Test plan

- [x] `npm run build` — 112 routes prerender clean
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx convex deploy` — `Remounted component rateLimiter` (data preserved), `No indexes deleted`
- [ ] **Manual reviewer:** sign in to dev, then in browser DevTools → Application → Cookies, confirm:
  - `__convexAuthJWT` and `__convexAuthRefreshToken` are present
  - Both have `Expires/Max-Age` ~60 days from now (not "Session")
  - `HttpOnly` and `SameSite=Lax` are checked
  - Close browser, reopen, navigate to `/account` — should still be signed in

## Out of scope (deferred)
- Optional "log out everywhere" UI (the lib supports `invalidateSessions(ctx, userId)` — would be a one-button addition in `/account`).
- Per-device session list / "this device" naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)