### PR TITLE
Fix crawler and hydration issues

### DIFF
--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -93,6 +93,16 @@ export default function BillsPage() {
     congress: 'all',
   });
   const [hasFilterChanges, setHasFilterChanges] = useState(false);
+  // The filter state above is seeded from localStorage in its initializers, so
+  // on the server (no localStorage) it is all defaults, while a returning user's
+  // browser restores their saved filters. Any markup that depends on filter
+  // state therefore differs between the server HTML and the first client render,
+  // which throws React hydration error #418. Gate such markup on `mounted` so it
+  // only renders after hydration, when client and server already agree.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     const fetchCongressInfo = async () => {
@@ -412,7 +422,7 @@ export default function BillsPage() {
               <Button variant="outline" className="w-full">
                 <SlidersHorizontal className="h-4 w-4" />
                 Filters
-                {filtersActive && (
+                {mounted && filtersActive && (
                   <span className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-accent" />
                 )}
               </Button>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+};
+
+// Intentionally a fully static server component — no data fetching, no cookies(),
+// no dynamic APIs. This keeps the not-found render cheap (it is the path bots hit
+// thousands of times) so it can never regress into expensive work, and gives a
+// branded 404 inside the normal nav/footer shell from the root layout.
+export default function NotFound() {
+  return (
+    <section className="border-b border-border">
+      <div className="container-editorial py-20 text-center sm:py-28">
+        <p className="label-eyebrow mb-3">Error 404</p>
+        <h1 className="font-serif text-display-md font-semibold leading-[1.05] tracking-tight sm:text-display-lg">
+          Page not found
+        </h1>
+        <p className="mx-auto mt-4 max-w-prose text-sm text-muted-foreground">
+          We couldn&rsquo;t find the page you&rsquo;re looking for. It may have
+          moved, or the link may be broken.
+        </p>
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Link
+            href="/"
+            className="inline-flex items-center rounded-sm bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+          >
+            Go home
+          </Link>
+          <Link
+            href="/bills"
+            className="inline-flex items-center rounded-sm border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-card"
+          >
+            Browse bills
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+// Serves /robots.txt (previously a 404). Well-behaved crawlers honor this;
+// malicious scanners ignore it — those are turned away at the Cloudflare edge.
+// `/account` is per-user and `/api/` is not meant to be crawled.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/account', '/api/'],
+    },
+    host: 'https://billsincongress.com',
+  };
+}


### PR DESCRIPTION
Adds a static branded 404 page so unknown routes render cheaply inside the app shell instead of falling through to a generic response.
Adds a Next metadata `robots.txt` route that allows public pages while excluding `/account` and `/api/` from well-behaved crawlers.
Guards the mobile bills filter active indicator until after mount to avoid localStorage-backed filter state causing a hydration mismatch.
Validated with `npx tsc --noEmit` and `npm run build`.