### PR TITLE
Fix bill data freshness & completeness at the sync-pipeline root cause

### DIFF
--- a/components/bills/bills-filter.tsx
+++ b/components/bills/bills-filter.tsx
@@ -63,6 +63,7 @@ const STATUS_OPTIONS = [
   { value: '40',  label: 'In committee' },
   { value: '60',  label: 'Passed one chamber' },
   { value: '80',  label: 'Passed both chambers' },
+  { value: '85',  label: 'Vetoed' },
   { value: '90',  label: 'To President' },
   { value: '95',  label: 'Signed by President' },
   { value: '100', label: 'Became law' },

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as ResendOTPPasswordReset from "../ResendOTPPasswordReset.js";
 import type * as aggregateBackfill from "../aggregateBackfill.js";
 import type * as aggregates from "../aggregates.js";
 import type * as auth from "../auth.js";
+import type * as billStage from "../billStage.js";
 import type * as bills from "../bills.js";
 import type * as chatAnalytics from "../chatAnalytics.js";
 import type * as congressApi from "../congressApi.js";
@@ -37,6 +38,7 @@ declare const fullApi: ApiFromModules<{
   aggregateBackfill: typeof aggregateBackfill;
   aggregates: typeof aggregates;
   auth: typeof auth;
+  billStage: typeof billStage;
   bills: typeof bills;
   chatAnalytics: typeof chatAnalytics;
   congressApi: typeof congressApi;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as ResendOTP from "../ResendOTP.js";
 import type * as ResendOTPPasswordReset from "../ResendOTPPasswordReset.js";
 import type * as aggregateBackfill from "../aggregateBackfill.js";
 import type * as aggregates from "../aggregates.js";
+import type * as audit from "../audit.js";
 import type * as auth from "../auth.js";
 import type * as billStage from "../billStage.js";
 import type * as bills from "../bills.js";
@@ -37,6 +38,7 @@ declare const fullApi: ApiFromModules<{
   ResendOTPPasswordReset: typeof ResendOTPPasswordReset;
   aggregateBackfill: typeof aggregateBackfill;
   aggregates: typeof aggregates;
+  audit: typeof audit;
   auth: typeof auth;
   billStage: typeof billStage;
   bills: typeof bills;

--- a/convex/aggregates.ts
+++ b/convex/aggregates.ts
@@ -2,6 +2,10 @@ import { TableAggregate } from "@convex-dev/aggregate";
 import { componentsGeneric } from "convex/server";
 import { DataModel } from "./_generated/dataModel";
 
+// Re-export the homepage status-chart stage list from the single source of
+// truth so callers (e.g. convex/mutations.ts) keep importing it from here.
+export { BILL_STAGES } from "./billStage";
+
 // Component handles. We resolve them via `componentsGeneric()` rather than the
 // `_generated/api.ts` re-export so this file typechecks locally without
 // requiring `npx convex codegen` to run with credentials. After
@@ -46,22 +50,6 @@ export const billsByStage = new TableAggregate<{
   namespace: (doc) => doc.congress,
   sortKey: (doc) => doc.progressStage ?? DEFAULT_STAGE,
 });
-
-/**
- * Bill stages that appear on the homepage status chart. Order matters here —
- * it controls the sort order of the chart segments.
- */
-export const BILL_STAGES: ReadonlyArray<{ stage: number; description: string }> =
-  [
-    { stage: 20, description: "Introduced" },
-    { stage: 40, description: "In Committee" },
-    { stage: 60, description: "Passed One Chamber" },
-    { stage: 80, description: "Passed Both Chambers" },
-    { stage: 85, description: "Vetoed" },
-    { stage: 90, description: "To President" },
-    { stage: 95, description: "Signed by President" },
-    { stage: 100, description: "Became Law" },
-  ];
 
 /**
  * Bill type prefixes for each chamber. Used to derive house/senate counts

--- a/convex/audit.ts
+++ b/convex/audit.ts
@@ -1,0 +1,753 @@
+/**
+ * TEMPORARY read-only audit module. Deployed to prod for a one-time data
+ * verification pass; performs NO writes. Not intended to be committed — safe to
+ * delete and redeploy. Compares the database against the live Library of
+ * Congress API and cross-checks internal consistency.
+ */
+import { internalAction, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import { calculateBillStage } from "./billStage";
+import {
+  EXTRA_LEGISLATIVE_SUBJECTS,
+  EXTRA_TEXT_VERSIONS,
+  EXTRA_COMPLETE,
+} from "./sync";
+
+const BASE_URL = "https://api.congress.gov/v3";
+const BILL_TYPES = [
+  "hr",
+  "s",
+  "hjres",
+  "sjres",
+  "hconres",
+  "sconres",
+  "hres",
+  "sres",
+];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function apiGet(path: string): Promise<any | null> {
+  const apiKey = process.env.CONGRESS_API_KEY;
+  if (!apiKey) throw new Error("CONGRESS_API_KEY not configured");
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const resp = await fetch(`${BASE_URL}${path}`, {
+        headers: { "X-Api-Key": apiKey },
+      });
+      if (resp.status === 429) {
+        await sleep(3000 * (attempt + 1));
+        continue;
+      }
+      if (!resp.ok) return null;
+      return await resp.json();
+    } catch {
+      await sleep(1000 * (attempt + 1));
+    }
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. Stage recompute + integrity audit (DB only)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const auditStagePage = internalQuery({
+  args: {
+    congress: v.number(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("bills")
+      .withIndex("by_congress", (q) => q.eq("congress", args.congress))
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+
+    let stageMismatchCount = 0;
+    let noActions = 0;
+    let missingIntroducedDate = 0;
+    let undefinedStage = 0;
+    let missingSponsor = 0;
+    let latestActionDateMissing = 0;
+    let latestActionDateStale = 0;
+    const mismatches: Array<{
+      billId: string;
+      stored: number | undefined;
+      recomputed: number;
+    }> = [];
+    const transitions: Record<string, number> = {};
+
+    for (const bill of page.page) {
+      if (!bill.introducedDate) missingIntroducedDate++;
+      if (bill.progressStage === undefined) undefinedStage++;
+      if (!bill.sponsorLastName) missingSponsor++;
+      if (!bill.latestActionDate) latestActionDateMissing++;
+
+      const actions = await ctx.db
+        .query("billActions")
+        .withIndex("by_billId", (q) => q.eq("billId", bill.billId))
+        .take(250);
+
+      if (actions.length === 0) {
+        noActions++;
+        continue;
+      }
+
+      // latestActionDate should equal the max actionDate of stored actions.
+      let maxDate = "";
+      for (const a of actions) if (a.actionDate > maxDate) maxDate = a.actionDate;
+      if (bill.latestActionDate && maxDate && bill.latestActionDate !== maxDate) {
+        latestActionDateStale++;
+      }
+
+      const { stage } = calculateBillStage(
+        actions.map((a) => ({
+          text: a.text,
+          type: a.type,
+          actionCode: a.actionCode,
+        })),
+      );
+      if (bill.progressStage !== stage) {
+        stageMismatchCount++;
+        const key = `${bill.progressStage}->${stage}`;
+        transitions[key] = (transitions[key] || 0) + 1;
+        if (mismatches.length < 15) {
+          mismatches.push({
+            billId: bill.billId,
+            stored: bill.progressStage,
+            recomputed: stage,
+          });
+        }
+      }
+    }
+
+    return {
+      scanned: page.page.length,
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+      stageMismatchCount,
+      noActions,
+      missingIntroducedDate,
+      undefinedStage,
+      missingSponsor,
+      latestActionDateMissing,
+      latestActionDateStale,
+      mismatches,
+      transitions,
+    };
+  },
+});
+
+export const auditStages = internalAction({
+  args: { congress: v.number() },
+  handler: async (ctx, args): Promise<any> => {
+    let cursor: string | null = null;
+    let scanned = 0,
+      stageMismatchCount = 0,
+      noActions = 0,
+      missingIntroducedDate = 0,
+      undefinedStage = 0,
+      missingSponsor = 0,
+      latestActionDateMissing = 0,
+      latestActionDateStale = 0;
+    const transitions: Record<string, number> = {};
+    const examples: any[] = [];
+
+    for (;;) {
+      const p: any = await ctx.runQuery(internal.audit.auditStagePage, {
+        congress: args.congress,
+        cursor,
+        numItems: 40,
+      });
+      scanned += p.scanned;
+      stageMismatchCount += p.stageMismatchCount;
+      noActions += p.noActions;
+      missingIntroducedDate += p.missingIntroducedDate;
+      undefinedStage += p.undefinedStage;
+      missingSponsor += p.missingSponsor;
+      latestActionDateMissing += p.latestActionDateMissing;
+      latestActionDateStale += p.latestActionDateStale;
+      for (const k in p.transitions)
+        transitions[k] = (transitions[k] || 0) + p.transitions[k];
+      for (const m of p.mismatches) if (examples.length < 40) examples.push(m);
+      if (p.isDone) break;
+      cursor = p.continueCursor;
+    }
+
+    console.log(
+      `auditStages c${args.congress}: scanned=${scanned} stageMismatches=${stageMismatchCount} noActions=${noActions}`,
+    );
+    return {
+      congress: args.congress,
+      scanned,
+      stageMismatchCount,
+      noActions,
+      missingIntroducedDate,
+      undefinedStage,
+      missingSponsor,
+      latestActionDateMissing,
+      latestActionDateStale,
+      transitions,
+      examples,
+    };
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. Census vs precomputed congressStats (DB only)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const getCongressStatsRow = internalQuery({
+  args: { congress: v.number() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("congressStats")
+      .withIndex("by_congress", (q) => q.eq("congress", args.congress))
+      .first();
+  },
+});
+
+export const auditCensus = internalAction({
+  args: {},
+  handler: async (ctx): Promise<any> => {
+    let cursor: string | null = null;
+    let grand = 0;
+    let dupCheckSample = 0;
+    const cong: Record<
+      number,
+      {
+        total: number;
+        house: number;
+        senate: number;
+        byType: Record<string, number>;
+        byStage: Record<number, number>;
+        missingStage: number;
+        subjectsDone: number;
+        textDone: number;
+        bothDone: number;
+        badType: number;
+      }
+    > = {};
+    const seenIds = new Set<string>();
+    let dupes = 0;
+    const dupeExamples: string[] = [];
+
+    for (;;) {
+      const p: any = await ctx.runQuery(
+        internal.mutations.getBillBackfillPage,
+        { cursor, numItems: 2000 },
+      );
+      for (const b of p.bills) {
+        grand++;
+        dupCheckSample++;
+        if (seenIds.has(b.billId)) {
+          dupes++;
+          if (dupeExamples.length < 10) dupeExamples.push(b.billId);
+        } else {
+          seenIds.add(b.billId);
+        }
+        const c =
+          cong[b.congress] ??
+          (cong[b.congress] = {
+            total: 0,
+            house: 0,
+            senate: 0,
+            byType: {},
+            byStage: {},
+            missingStage: 0,
+            subjectsDone: 0,
+            textDone: 0,
+            bothDone: 0,
+            badType: 0,
+          });
+        c.total++;
+        if (b.billType.startsWith("h")) c.house++;
+        else if (b.billType.startsWith("s")) c.senate++;
+        if (!BILL_TYPES.includes(b.billType)) c.badType++;
+        c.byType[b.billType] = (c.byType[b.billType] || 0) + 1;
+        if (b.progressStage === undefined) c.missingStage++;
+        else c.byStage[b.progressStage] = (c.byStage[b.progressStage] || 0) + 1;
+        if (b.extraSyncedBits & EXTRA_LEGISLATIVE_SUBJECTS) c.subjectsDone++;
+        if (b.extraSyncedBits & EXTRA_TEXT_VERSIONS) c.textDone++;
+        if ((b.extraSyncedBits & EXTRA_COMPLETE) === EXTRA_COMPLETE)
+          c.bothDone++;
+      }
+      if (p.isDone) break;
+      cursor = p.continueCursor;
+    }
+
+    const comparison: any[] = [];
+    for (const cs of Object.keys(cong)
+      .map(Number)
+      .sort((a, b) => a - b)) {
+      const raw = cong[cs];
+      const stats: any = await ctx.runQuery(internal.audit.getCongressStatsRow, {
+        congress: cs,
+      });
+      const statsByStage = stats
+        ? Object.fromEntries(stats.stageCounts.map((s: any) => [s.stage, s.count]))
+        : null;
+      // diff raw vs stats per stage
+      const stageDiffs: Record<string, { raw: number; stats: number }> = {};
+      if (statsByStage) {
+        const allStages = new Set<number>([
+          ...Object.keys(raw.byStage).map(Number),
+          ...Object.keys(statsByStage).map(Number),
+        ]);
+        for (const st of allStages) {
+          const r = raw.byStage[st] ?? 0;
+          const s = statsByStage[st] ?? 0;
+          if (r !== s) stageDiffs[st] = { raw: r, stats: s };
+        }
+      }
+      comparison.push({
+        congress: cs,
+        rawTotal: raw.total,
+        statsTotal: stats?.totalCount ?? null,
+        totalMatch: stats ? raw.total === stats.totalCount : false,
+        rawHouse: raw.house,
+        statsHouse: stats?.houseCount ?? null,
+        rawSenate: raw.senate,
+        statsSenate: stats?.senateCount ?? null,
+        houseMatch: stats ? raw.house === stats.houseCount : false,
+        senateMatch: stats ? raw.senate === stats.senateCount : false,
+        stageDiffs,
+        byType: raw.byType,
+        byStage: raw.byStage,
+        missingStage: raw.missingStage,
+        badType: raw.badType,
+        subjectsDone: raw.subjectsDone,
+        textDone: raw.textDone,
+        bothDone: raw.bothDone,
+      });
+    }
+
+    return { grand, dupes, dupeExamples, comparison };
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. DB counts vs live API counts per (congress, billType)
+// ─────────────────────────────────────────────────────────────────────────
+
+export const auditCountsVsApi = internalAction({
+  args: { congresses: v.optional(v.array(v.number())) },
+  handler: async (ctx, args): Promise<any> => {
+    let cursor: string | null = null;
+    const db: Record<string, number> = {};
+    const seen = new Set<number>();
+    for (;;) {
+      const p: any = await ctx.runQuery(
+        internal.mutations.getBillBackfillPage,
+        { cursor, numItems: 2000 },
+      );
+      for (const b of p.bills) {
+        db[`${b.congress}/${b.billType}`] =
+          (db[`${b.congress}/${b.billType}`] || 0) + 1;
+        seen.add(b.congress);
+      }
+      if (p.isDone) break;
+      cursor = p.continueCursor;
+    }
+
+    const congresses = args.congresses ?? [...seen].sort((a, b) => a - b);
+    const rows: any[] = [];
+    for (const c of congresses) {
+      for (const t of BILL_TYPES) {
+        await sleep(300);
+        const data = await apiGet(`/bill/${c}/${t}?limit=1&format=json`);
+        const apiCount = data?.pagination?.count ?? null;
+        const dbCount = db[`${c}/${t}`] ?? 0;
+        rows.push({
+          congress: c,
+          billType: t,
+          dbCount,
+          apiCount,
+          diff: apiCount === null ? null : apiCount - dbCount,
+        });
+      }
+    }
+    return { rows };
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. Deep per-bill comparison: DB vs live API
+// ─────────────────────────────────────────────────────────────────────────
+
+export const getStoredBill = internalQuery({
+  args: { billId: v.string() },
+  handler: async (ctx, args) => {
+    const bill = await ctx.db
+      .query("bills")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .first();
+    if (!bill) return null;
+    const actions = await ctx.db
+      .query("billActions")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(250);
+    const subject = await ctx.db
+      .query("billSubjects")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .first();
+    const legSubjects = await ctx.db
+      .query("billLegislativeSubjects")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(1000);
+    const summaries = await ctx.db
+      .query("billSummaries")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(100);
+    const texts = await ctx.db
+      .query("billText")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(100);
+    let maxActionDate = "";
+    for (const a of actions) if (a.actionDate > maxActionDate) maxActionDate = a.actionDate;
+    return {
+      billId: bill.billId,
+      congress: bill.congress,
+      billType: bill.billType,
+      billNumber: bill.billNumber,
+      progressStage: bill.progressStage,
+      introducedDate: bill.introducedDate,
+      latestActionDate: bill.latestActionDate,
+      sponsorFirstName: bill.sponsorFirstName,
+      sponsorLastName: bill.sponsorLastName,
+      sponsorParty: bill.sponsorParty,
+      sponsorState: bill.sponsorState,
+      extraSyncedBits: bill.extraSyncedBits ?? 0,
+      actionCount: actions.length,
+      maxActionDate,
+      recomputedStageFromStored: calculateBillStage(
+        actions.map((a) => ({
+          text: a.text,
+          type: a.type,
+          actionCode: a.actionCode,
+        })),
+      ).stage,
+      policyAreaName: subject?.policyAreaName ?? null,
+      legSubjectCount: legSubjects.length,
+      summaryCount: summaries.length,
+      textCount: texts.length,
+      textTypes: texts.map((t) => t.type),
+    };
+  },
+});
+
+// Confirm whether the live /subjects pagination.count includes the policyArea
+// (which would explain the uniform +1 vs our stored legislativeSubjects).
+export const auditSubjectsRaw = internalAction({
+  args: { billId: v.string() },
+  handler: async (ctx, args): Promise<any> => {
+    const m = args.billId.match(/^(\d+)([a-z]+)(\d+)$/);
+    if (!m) return { error: "unparseable" };
+    const [, number, billType, congress] = m;
+    const data = await apiGet(
+      `/bill/${congress}/${billType}/${number}/subjects?format=json&limit=250`,
+    );
+    const legislativeSubjects = data?.subjects?.legislativeSubjects ?? [];
+    const policyArea = data?.subjects?.policyArea ?? null;
+    return {
+      billId: args.billId,
+      paginationCount: data?.pagination?.count ?? null,
+      legislativeSubjectsLength: legislativeSubjects.length,
+      hasPolicyArea: policyArea !== null,
+      policyAreaName: policyArea?.name ?? null,
+      // count - legislativeSubjects should equal 1 if policyArea is included.
+      countMinusLegSubjects:
+        (data?.pagination?.count ?? 0) - legislativeSubjects.length,
+    };
+  },
+});
+
+// Sample bills across a congress, recompute stage from LIVE actions, and
+// compare to the stored stage — estimates the rate of stage staleness vs the
+// live source. One API call per sampled bill (the actions endpoint).
+export const auditStageVsApiSample = internalAction({
+  args: { congress: v.number(), sampleSize: v.number() },
+  handler: async (ctx, args): Promise<any> => {
+    const all: Array<{
+      billId: string;
+      billType: string;
+      billNumber: string;
+      progressStage?: number;
+    }> = [];
+    let cursor: string | null = null;
+    for (;;) {
+      const p: any = await ctx.runQuery(internal.audit.getBillNumbersForCongress, {
+        congress: args.congress,
+        cursor,
+        numItems: 2000,
+      });
+      for (const b of p.bills) all.push(b);
+      if (p.isDone) break;
+      cursor = p.continueCursor;
+    }
+    if (all.length === 0) return { congress: args.congress, sampled: 0 };
+    const step = Math.max(1, Math.floor(all.length / args.sampleSize));
+    const sample = [];
+    for (let i = 0; i < all.length && sample.length < args.sampleSize; i += step)
+      sample.push(all[i]);
+
+    let checked = 0;
+    let mismatches = 0;
+    const examples: any[] = [];
+    for (const b of sample) {
+      await sleep(280);
+      const data = await apiGet(
+        `/bill/${args.congress}/${b.billType}/${b.billNumber}/actions?format=json&limit=250`,
+      );
+      if (!data) continue;
+      const liveActions = (data.actions ?? []).map((a: any) => ({
+        text: a.text || "",
+        type: a.type,
+        actionCode: a.actionCode,
+      }));
+      if (liveActions.length === 0) continue;
+      checked++;
+      const liveStage = calculateBillStage(liveActions).stage;
+      if (liveStage !== b.progressStage) {
+        mismatches++;
+        if (examples.length < 25)
+          examples.push({
+            billId: b.billId,
+            stored: b.progressStage,
+            live: liveStage,
+          });
+      }
+    }
+    return {
+      congress: args.congress,
+      totalBills: all.length,
+      requested: args.sampleSize,
+      checked,
+      mismatches,
+      mismatchPct: checked ? ((mismatches / checked) * 100).toFixed(1) : null,
+      examples,
+    };
+  },
+});
+
+export const getBillNumbersForCongress = internalQuery({
+  args: {
+    congress: v.number(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("bills")
+      .withIndex("by_congress", (q) => q.eq("congress", args.congress))
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+    return {
+      bills: page.page.map((b) => ({
+        billId: b.billId,
+        billType: b.billType,
+        billNumber: b.billNumber,
+        progressStage: b.progressStage,
+      })),
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+    };
+  },
+});
+
+export const getBillNumbersPage = internalQuery({
+  args: {
+    congress: v.number(),
+    billType: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("bills")
+      .withIndex("by_congress_and_type", (q) =>
+        q.eq("congress", args.congress).eq("billType", args.billType),
+      )
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+    return {
+      numbers: page.page.map((b) => b.billNumber),
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+    };
+  },
+});
+
+// Identify exactly which bills the live API has that the DB lacks (missing) and
+// vice versa (extra/stale), for one (congress, billType).
+export const auditMissingBills = internalAction({
+  args: { congress: v.number(), billType: v.string() },
+  handler: async (ctx, args): Promise<any> => {
+    // DB set
+    const dbSet = new Set<string>();
+    let cursor: string | null = null;
+    for (;;) {
+      const p: any = await ctx.runQuery(internal.audit.getBillNumbersPage, {
+        congress: args.congress,
+        billType: args.billType,
+        cursor,
+        numItems: 2000,
+      });
+      for (const n of p.numbers) dbSet.add(String(n));
+      if (p.isDone) break;
+      cursor = p.continueCursor;
+    }
+    // API set (paginate the list endpoint)
+    const apiSet = new Set<string>();
+    let offset = 0;
+    let apiCount: number | null = null;
+    for (let i = 0; i < 250; i++) {
+      await sleep(280);
+      const data = await apiGet(
+        `/bill/${args.congress}/${args.billType}?limit=250&offset=${offset}&format=json`,
+      );
+      if (!data) break;
+      if (apiCount === null) apiCount = data?.pagination?.count ?? null;
+      const bills = data.bills ?? [];
+      for (const b of bills) apiSet.add(String(b.number));
+      if (bills.length < 250) break;
+      offset += 250;
+    }
+    const missingFromDb = [...apiSet].filter((n) => !dbSet.has(n));
+    const extraInDb = [...dbSet].filter((n) => !apiSet.has(n));
+    return {
+      congress: args.congress,
+      billType: args.billType,
+      dbSize: dbSet.size,
+      apiSize: apiSet.size,
+      apiCount,
+      missingFromDb: missingFromDb
+        .map(Number)
+        .sort((a, b) => a - b)
+        .map((n) => `${n}${args.billType}${args.congress}`),
+      extraInDb: extraInDb
+        .map(Number)
+        .sort((a, b) => a - b)
+        .map((n) => `${n}${args.billType}${args.congress}`),
+    };
+  },
+});
+
+export const auditBillVsApi = internalAction({
+  args: { billId: v.string() },
+  handler: async (ctx, args): Promise<any> => {
+    const m = args.billId.match(/^(\d+)([a-z]+)(\d+)$/);
+    if (!m) return { billId: args.billId, error: "unparseable billId" };
+    const [, number, billType, congress] = m;
+
+    const stored: any = await ctx.runQuery(internal.audit.getStoredBill, {
+      billId: args.billId,
+    });
+    if (!stored) return { billId: args.billId, error: "not in DB" };
+
+    const base = `/bill/${congress}/${billType}/${number}`;
+    const detail = await apiGet(`${base}?format=json`);
+    await sleep(250);
+    const actionsResp = await apiGet(`${base}/actions?format=json&limit=250`);
+    await sleep(250);
+    const subjectsResp = await apiGet(`${base}/subjects?format=json&limit=250`);
+    await sleep(250);
+    const summariesResp = await apiGet(`${base}/summaries?format=json`);
+    await sleep(250);
+    const textResp = await apiGet(`${base}/text?format=json`);
+
+    const liveActions = (actionsResp?.actions ?? []).map((a: any) => ({
+      text: a.text || "",
+      type: a.type,
+      actionCode: a.actionCode,
+      actionDate: a.actionDate || "",
+    }));
+    const liveStage =
+      liveActions.length > 0 ? calculateBillStage(liveActions).stage : null;
+    let liveMaxActionDate = "";
+    for (const a of liveActions)
+      if (a.actionDate > liveMaxActionDate) liveMaxActionDate = a.actionDate;
+
+    const d = detail?.bill;
+    const liveSponsor = d?.sponsors?.[0];
+    const livePolicyArea = subjectsResp?.subjects?.policyArea?.name ?? null;
+    const liveLegSubjectCount = subjectsResp?.pagination?.count ?? null;
+    const liveSummaryCount = summariesResp?.summaries?.length ?? null;
+    const liveTextCount = textResp?.textVersions?.length ?? null;
+
+    const discrepancies: string[] = [];
+    const norm = (s: any) => (s ?? "").toString().trim();
+    if (liveStage !== null && liveStage !== stored.progressStage)
+      discrepancies.push(
+        `stage: stored=${stored.progressStage} liveRecomputed=${liveStage}`,
+      );
+    if (norm(d?.introducedDate) && norm(d?.introducedDate) !== norm(stored.introducedDate))
+      discrepancies.push(
+        `introducedDate: stored=${stored.introducedDate} live=${d?.introducedDate}`,
+      );
+    if (liveMaxActionDate && liveMaxActionDate !== norm(stored.latestActionDate))
+      discrepancies.push(
+        `latestActionDate: stored=${stored.latestActionDate} live=${liveMaxActionDate}`,
+      );
+    if (liveSponsor && norm(liveSponsor.lastName) !== norm(stored.sponsorLastName))
+      discrepancies.push(
+        `sponsorLast: stored=${stored.sponsorLastName} live=${liveSponsor.lastName}`,
+      );
+    if (liveSponsor && norm(liveSponsor.party) !== norm(stored.sponsorParty))
+      discrepancies.push(
+        `sponsorParty: stored=${stored.sponsorParty} live=${liveSponsor.party}`,
+      );
+    if (liveSponsor && norm(liveSponsor.state) !== norm(stored.sponsorState))
+      discrepancies.push(
+        `sponsorState: stored=${stored.sponsorState} live=${liveSponsor.state}`,
+      );
+    if (livePolicyArea && norm(livePolicyArea) !== norm(stored.policyAreaName))
+      discrepancies.push(
+        `policyArea: stored=${stored.policyAreaName} live=${livePolicyArea}`,
+      );
+    // Enrichment fidelity (only meaningful once the bill is enriched).
+    const enrichedSubjects =
+      (stored.extraSyncedBits & EXTRA_LEGISLATIVE_SUBJECTS) !== 0;
+    if (
+      enrichedSubjects &&
+      liveLegSubjectCount !== null &&
+      liveLegSubjectCount !== stored.legSubjectCount
+    )
+      discrepancies.push(
+        `legSubjects: stored=${stored.legSubjectCount} live=${liveLegSubjectCount}`,
+      );
+
+    return {
+      billId: args.billId,
+      stored: {
+        stage: stored.progressStage,
+        recomputedFromStored: stored.recomputedStageFromStored,
+        actionCount: stored.actionCount,
+        latestActionDate: stored.latestActionDate,
+        sponsor: `${stored.sponsorFirstName ?? ""} ${stored.sponsorLastName ?? ""} (${stored.sponsorParty ?? "?"}-${stored.sponsorState ?? "?"})`,
+        policyArea: stored.policyAreaName,
+        legSubjectCount: stored.legSubjectCount,
+        summaryCount: stored.summaryCount,
+        textCount: stored.textCount,
+        enrichedBits: stored.extraSyncedBits,
+      },
+      live: {
+        stage: liveStage,
+        actionCount: liveActions.length,
+        latestActionDate: liveMaxActionDate,
+        sponsor: liveSponsor
+          ? `${liveSponsor.firstName ?? ""} ${liveSponsor.lastName ?? ""} (${liveSponsor.party ?? "?"}-${liveSponsor.state ?? "?"})`
+          : null,
+        policyArea: livePolicyArea,
+        legSubjectCount: liveLegSubjectCount,
+        summaryCount: liveSummaryCount,
+        textCount: liveTextCount,
+        title: d?.title ?? null,
+      },
+      discrepancies,
+      clean: discrepancies.length === 0,
+    };
+  },
+});

--- a/convex/billStage.test.ts
+++ b/convex/billStage.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the bill-stage calculator. The calculator rewrites every
+ * bill's progress stage, so it carries a permanent regression test.
+ *
+ * Run with: `npm test` (which runs `tsx convex/billStage.test.ts`). Uses
+ * node:assert rather than a test framework to avoid adding a dependency — this
+ * file is excluded from Convex bundling because its name ends in `.test.ts`.
+ */
+import assert from "node:assert/strict";
+import { calculateBillStage, BillStages } from "./billStage";
+
+type Action = { text: string; type?: string; actionCode?: string };
+
+const a = (text: string, extra: Partial<Action> = {}): Action => ({
+  text,
+  ...extra,
+});
+
+let passed = 0;
+const failures: string[] = [];
+
+function it(name: string, fn: () => void) {
+  try {
+    fn();
+    passed++;
+  } catch (err) {
+    failures.push(
+      `  ✗ ${name}\n    ${err instanceof Error ? err.message.split("\n").join("\n    ") : String(err)}`,
+    );
+  }
+}
+
+const stageOf = (actions: Action[]) => calculateBillStage(actions).stage;
+
+it("returns Introduced (20) for no actions", () => {
+  assert.equal(stageOf([]), BillStages.INTRODUCED);
+});
+
+it("returns Introduced (20) for an unrecognised action", () => {
+  assert.equal(
+    stageOf([a("Sponsor introductory remarks on measure.")]),
+    BillStages.INTRODUCED,
+  );
+});
+
+it("returns In Committee (40) when referred to a committee", () => {
+  assert.equal(
+    stageOf([
+      a("Introduced in House"),
+      a("Referred to the Committee on the Judiciary."),
+    ]),
+    BillStages.IN_COMMITTEE,
+  );
+});
+
+it("returns Passed One Chamber (60) when only one chamber passed", () => {
+  assert.equal(
+    stageOf([
+      a("Referred to the Committee on Finance."),
+      a("Passed House", { type: "PassedHouse" }),
+    ]),
+    BillStages.PASSED_ONE_CHAMBER,
+  );
+});
+
+it("returns Passed Both Chambers (80) when both chambers passed but not yet to president", () => {
+  assert.equal(
+    stageOf([
+      a("Passed House", { actionCode: "H32500" }),
+      a("Passed Senate", { actionCode: "S32500" }),
+    ]),
+    BillStages.PASSED_BOTH_CHAMBERS,
+  );
+});
+
+it("returns To President (90) when presented to the president (not yet signed/vetoed)", () => {
+  assert.equal(
+    stageOf([
+      a("Passed House"),
+      a("Passed Senate"),
+      a("Presented to President.", { actionCode: "E20000" }),
+    ]),
+    BillStages.TO_PRESIDENT,
+  );
+});
+
+it("returns Signed (95) on 'Signed by President' text — even when that action also carries E30000", () => {
+  assert.equal(
+    stageOf([
+      a("Presented to President.", { actionCode: "E20000" }),
+      a("Signed by President.", { actionCode: "E30000" }),
+    ]),
+    BillStages.SIGNED_BY_PRESIDENT,
+  );
+});
+
+it("returns Became Law (100) on 'Became Public Law'", () => {
+  assert.equal(
+    stageOf([
+      a("Signed by President.", { actionCode: "E30000" }),
+      a("Became Public Law No: 118-42.", { actionCode: "E40000" }),
+    ]),
+    BillStages.BECAME_LAW,
+  );
+});
+
+// ─── THE BUG: a veto action carries the SAME E30000 code as a signing. ───
+it("returns Vetoed (85) for a veto that carries E30000 (the real-world bug)", () => {
+  assert.equal(
+    stageOf([
+      a("Presented to President.", { actionCode: "E20000" }),
+      a("Vetoed by President.", { actionCode: "E30000" }),
+    ]),
+    BillStages.VETOED,
+  );
+});
+
+it("returns Vetoed (85) regardless of action order (veto appears first)", () => {
+  assert.equal(
+    stageOf([
+      a("Vetoed by President.", { actionCode: "E30000" }),
+      a("Referred to the Committee on Armed Services."),
+      a("Passed House"),
+      a("Passed Senate"),
+    ]),
+    BillStages.VETOED,
+  );
+});
+
+it("returns Vetoed (85) for a pocket veto", () => {
+  assert.equal(stageOf([a("Pocket Vetoed by President.")]), BillStages.VETOED);
+});
+
+it("prefers Vetoed (85) over Signed (95) when both flags are present", () => {
+  assert.equal(
+    stageOf([a("Signed by President."), a("Vetoed by President.")]),
+    BillStages.VETOED,
+  );
+});
+
+it("prefers Became Law (100) over a veto (override case)", () => {
+  assert.equal(
+    stageOf([
+      a("Vetoed by President."),
+      a("Passed House over veto."),
+      a("Passed Senate over veto."),
+      a("Became Public Law No: 118-31."),
+    ]),
+    BillStages.BECAME_LAW,
+  );
+});
+
+if (failures.length > 0) {
+  console.error(`\nbillStage: ${passed} passed, ${failures.length} FAILED\n`);
+  console.error(failures.join("\n\n"));
+  process.exit(1);
+}
+console.log(`billStage: all ${passed} tests passed`);

--- a/convex/billStage.ts
+++ b/convex/billStage.ts
@@ -1,0 +1,169 @@
+/**
+ * Single source of truth for bill progress stages and the logic that derives a
+ * stage from a bill's legislative actions.
+ *
+ * This module is intentionally PURE (no Convex imports) so it can be unit
+ * tested in isolation and imported anywhere on the backend. The sync pipeline,
+ * the repair/backfill jobs, and the precomputed-stats aggregates all derive
+ * their notion of "stage" from here — keep it the only definition.
+ */
+
+export const BillStages = {
+  INTRODUCED: 20,
+  IN_COMMITTEE: 40,
+  PASSED_ONE_CHAMBER: 60,
+  PASSED_BOTH_CHAMBERS: 80,
+  VETOED: 85,
+  TO_PRESIDENT: 90,
+  SIGNED_BY_PRESIDENT: 95,
+  BECAME_LAW: 100,
+} as const;
+
+export const BillStageDescriptions: Record<number, string> = {
+  [BillStages.INTRODUCED]: "Introduced",
+  [BillStages.IN_COMMITTEE]: "In Committee",
+  [BillStages.PASSED_ONE_CHAMBER]: "Passed One Chamber",
+  [BillStages.PASSED_BOTH_CHAMBERS]: "Passed Both Chambers",
+  [BillStages.VETOED]: "Vetoed",
+  [BillStages.TO_PRESIDENT]: "To President",
+  [BillStages.SIGNED_BY_PRESIDENT]: "Signed by President",
+  [BillStages.BECAME_LAW]: "Became Law",
+};
+
+/**
+ * Stages that appear on the homepage status chart, in display order. The chart
+ * segments are sorted by this array's order. Used by the precomputed-stats
+ * aggregates (`convex/aggregates.ts`).
+ */
+export const BILL_STAGES: ReadonlyArray<{ stage: number; description: string }> =
+  [
+    BillStages.INTRODUCED,
+    BillStages.IN_COMMITTEE,
+    BillStages.PASSED_ONE_CHAMBER,
+    BillStages.PASSED_BOTH_CHAMBERS,
+    BillStages.VETOED,
+    BillStages.TO_PRESIDENT,
+    BillStages.SIGNED_BY_PRESIDENT,
+    BillStages.BECAME_LAW,
+  ].map((stage) => ({ stage, description: BillStageDescriptions[stage] }));
+
+/**
+ * Derive a bill's progress stage from its actions.
+ *
+ * Flag-based with post-loop precedence — there are NO early returns inside the
+ * scan. This is deliberate and fixes a real production bug: the Library of
+ * Congress API attaches the SAME action code (`E30000`) to both "Signed by
+ * President" and "Vetoed by President". The previous implementation early-
+ * returned "Signed" the moment it saw `E30000`, so genuine vetoes (e.g. the
+ * 118th Congress JUDGES Act and the CRA disapproval resolutions) were
+ * mislabeled as signed-into-law. Here we scan every action, set independent
+ * booleans, then pick the most advanced stage — and `E30000` is no longer used
+ * to detect a signing at all (a signing is recognised only by its unambiguous
+ * "Signed by President" text).
+ *
+ * Precedence (most advanced first): became law > vetoed > signed > to
+ * president > passed both > passed one > in committee > introduced. Vetoed
+ * outranks signed defensively so a veto can never be reported as a signing.
+ */
+export function calculateBillStage(
+  actions: Array<{ text: string; type?: string; actionCode?: string }>,
+): { stage: number; description: string } {
+  const stageResult = (stage: number) => ({
+    stage,
+    description: BillStageDescriptions[stage],
+  });
+
+  if (!actions || !Array.isArray(actions) || actions.length === 0) {
+    return stageResult(BillStages.INTRODUCED);
+  }
+
+  let becameLaw = false;
+  let vetoed = false;
+  let signed = false;
+  let toPresident = false;
+  let passedHouse = false;
+  let passedSenate = false;
+  let inCommittee = false;
+
+  for (const action of actions) {
+    const text = (action.text || "").toLowerCase();
+    const type = (action.type || "").toLowerCase();
+    const code = action.actionCode || "";
+
+    if (
+      text.includes("became public law") ||
+      text.includes("became private law") ||
+      type === "becamelaw" ||
+      code === "36000" ||
+      code === "E40000"
+    ) {
+      becameLaw = true;
+    }
+
+    // Veto detection. `E30000` is deliberately NOT used here or for "signed";
+    // it is ambiguous between the two. A veto is recognised by its text
+    // ("Vetoed by President.", "Pocket Vetoed by President.", "Veto Message
+    // received"), its action type, or the unambiguous veto code 31000.
+    if (
+      text.includes("vetoed") ||
+      text.includes("veto message") ||
+      text.includes("pocket veto") ||
+      type === "vetoed" ||
+      type === "veto" ||
+      code === "31000"
+    ) {
+      vetoed = true;
+    }
+
+    // Signing is recognised ONLY by its unambiguous text (never by E30000).
+    if (text.includes("signed by president")) {
+      signed = true;
+    }
+
+    if (
+      text.includes("presented to president") ||
+      text.includes("to president") ||
+      code === "28000" ||
+      code === "E20000"
+    ) {
+      toPresident = true;
+    }
+
+    if (
+      text.includes("passed house") ||
+      type === "passedhouse" ||
+      code === "H32500"
+    ) {
+      passedHouse = true;
+    }
+    if (
+      text.includes("passed senate") ||
+      type === "passedsenate" ||
+      code === "S32500"
+    ) {
+      passedSenate = true;
+    }
+
+    if (
+      text.includes("referred to") ||
+      text.includes("committee") ||
+      code === "5000" ||
+      code === "14000" ||
+      code === "H11100" ||
+      code === "S11100"
+    ) {
+      inCommittee = true;
+    }
+  }
+
+  if (becameLaw) return stageResult(BillStages.BECAME_LAW);
+  if (vetoed) return stageResult(BillStages.VETOED);
+  if (signed) return stageResult(BillStages.SIGNED_BY_PRESIDENT);
+  if (toPresident) return stageResult(BillStages.TO_PRESIDENT);
+  if (passedHouse && passedSenate)
+    return stageResult(BillStages.PASSED_BOTH_CHAMBERS);
+  if (passedHouse || passedSenate)
+    return stageResult(BillStages.PASSED_ONE_CHAMBER);
+  if (inCommittee) return stageResult(BillStages.IN_COMMITTEE);
+  return stageResult(BillStages.INTRODUCED);
+}

--- a/convex/bills.ts
+++ b/convex/bills.ts
@@ -169,6 +169,39 @@ export const debugBillStage = internalQuery({
   },
 });
 
+/**
+ * Read-only spot-check for the enrichment backfill: reports a bill's
+ * extraSyncedBits, how many legislative subjects and text versions are stored,
+ * and small samples. Compare the subject count against the live
+ * `/subjects` `pagination.count` (e.g. 1hr119 ≈ 239) to confirm fidelity.
+ *   npx convex run bills:debugBillEnrichment '{"billId":"1hr119"}'
+ */
+export const debugBillEnrichment = internalQuery({
+  args: { billId: v.string() },
+  handler: async (ctx, args) => {
+    const bill = await ctx.db
+      .query("bills")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .first();
+    const legislativeSubjects = await ctx.db
+      .query("billLegislativeSubjects")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(500);
+    const texts = await ctx.db
+      .query("billText")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(100);
+    return {
+      billId: args.billId,
+      extraSyncedBits: bill?.extraSyncedBits ?? 0,
+      legislativeSubjectCount: legislativeSubjects.length,
+      sampleSubjects: legislativeSubjects.slice(0, 8).map((s) => s.name),
+      textVersionCount: texts.length,
+      textVersionTypes: texts.map((t) => t.type),
+    };
+  },
+});
+
 // A bill stores at most 250 actions (the sync fetches with limit=250).
 const MAX_BILL_ACTIONS = 250;
 const RECENT_ACTIONS_LIMIT = 20;

--- a/convex/bills.ts
+++ b/convex/bills.ts
@@ -2,18 +2,70 @@ import { query, internalQuery, QueryCtx } from "./_generated/server";
 import { Doc } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { billsByChamber, billsByStage } from "./aggregates";
+import { calculateBillStage } from "./billStage";
 
-// Bill stage constants (mirroring lib/utils/bill-stages.ts)
-const BILL_STAGE_DESCRIPTIONS: Record<number, string> = {
-  20: "Introduced",
-  40: "In Committee",
-  60: "Passed One Chamber",
-  80: "Passed Both Chambers",
-  85: "Vetoed",
-  90: "To President",
-  95: "Signed by President",
-  100: "Became Law",
-};
+// Bounds for reading a single bill's child rows. Real bills have only a handful
+// of summaries / text versions, so these caps are generous safety limits.
+const MAX_SUMMARIES_PER_BILL = 50;
+const MAX_TEXT_VERSIONS_PER_BILL = 50;
+
+/** Effective date for ordering a summary: prefer actionDate, fall back to updateDate. */
+function summaryEffectiveDate(s: Doc<"billSummaries">): string {
+  return s.actionDate || s.updateDate || "";
+}
+
+/**
+ * Pick the summary describing the most advanced action — the one with the
+ * latest effective date. The Library of Congress returns summaries in an order
+ * that is NOT chronological, so we must select by date rather than by array
+ * position / `_creationTime`.
+ */
+function pickLatestSummary(
+  summaries: Doc<"billSummaries">[],
+): Doc<"billSummaries"> | null {
+  if (summaries.length === 0) return null;
+  return [...summaries].sort((a, b) => {
+    const da = summaryEffectiveDate(a);
+    const db = summaryEffectiveDate(b);
+    return da < db ? 1 : da > db ? -1 : 0;
+  })[0];
+}
+
+/**
+ * Rank a bill-text version by how final it is. The "current" text is the most
+ * advanced version that exists (a signed Public Law supersedes the Enrolled
+ * copy, which supersedes Engrossed, etc.).
+ */
+function textVersionRank(type: string | undefined): number {
+  const t = (type || "").toLowerCase();
+  if (t.includes("public law") || t.includes("private law")) return 100;
+  if (t.includes("enrolled")) return 90;
+  if (t.includes("engrossed amendment")) return 80;
+  if (t.includes("engrossed")) return 70;
+  if (t.includes("reported")) return 60;
+  if (t.includes("placed on calendar")) return 55;
+  if (t.includes("referred")) return 50;
+  if (t.includes("considered")) return 45;
+  if (t.includes("introduced")) return 40;
+  return 10;
+}
+
+/**
+ * Pick the current text version: most final by rank, then most recent by date.
+ * Works on the single legacy row stored today and improves automatically once
+ * the sync stores every text version.
+ */
+function pickCurrentText(texts: Doc<"billText">[]): Doc<"billText"> | null {
+  if (texts.length === 0) return null;
+  return [...texts].sort((a, b) => {
+    const ra = textVersionRank(a.type);
+    const rb = textVersionRank(b.type);
+    if (ra !== rb) return rb - ra;
+    const da = a.date || "";
+    const db = b.date || "";
+    return da < db ? 1 : da > db ? -1 : 0;
+  })[0];
+}
 
 /**
  * Internal helper: check if any bills exist for a given congress.
@@ -43,8 +95,10 @@ export const getById = query({
 
     if (!bill) return null;
 
-    // Fetch related data in parallel
-    const [subjects, summary, text] = await Promise.all([
+    // Fetch related data in parallel. Summaries and text versions are selected
+    // by date / finality (see helpers above), NOT by array position — the
+    // Library of Congress does not return them in chronological order.
+    const [subjects, summaries, texts] = await Promise.all([
       ctx.db
         .query("billSubjects")
         .withIndex("by_billId", (q) => q.eq("billId", args.billId))
@@ -52,14 +106,15 @@ export const getById = query({
       ctx.db
         .query("billSummaries")
         .withIndex("by_billId", (q) => q.eq("billId", args.billId))
-        .order("desc")
-        .first(),
+        .take(MAX_SUMMARIES_PER_BILL),
       ctx.db
         .query("billText")
         .withIndex("by_billId", (q) => q.eq("billId", args.billId))
-        .order("desc")
-        .first(),
+        .take(MAX_TEXT_VERSIONS_PER_BILL),
     ]);
+
+    const summary = pickLatestSummary(summaries);
+    const text = pickCurrentText(texts);
 
     return {
       ...bill,
@@ -73,7 +128,61 @@ export const getById = query({
 });
 
 /**
- * Get bill actions for a specific bill (internal query)
+ * Read-only diagnostic: dump a bill's stored actions (code/type/text/date) and
+ * compare its stored stage against the freshly-computed one. Used to verify the
+ * veto-detection fix against production data without any API calls, e.g.
+ *   npx convex run bills:debugBillStage '{"billId":"4199s118"}'
+ */
+export const debugBillStage = internalQuery({
+  args: { billId: v.string() },
+  handler: async (ctx, args) => {
+    const bill = await ctx.db
+      .query("bills")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .first();
+    const actions = await ctx.db
+      .query("billActions")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .take(250);
+    const computed = calculateBillStage(
+      actions.map((a) => ({
+        text: a.text,
+        type: a.type,
+        actionCode: a.actionCode,
+      })),
+    );
+    return {
+      billId: args.billId,
+      exists: bill !== null,
+      storedStage: bill?.progressStage,
+      storedDescription: bill?.progressDescription,
+      computedStage: computed.stage,
+      computedDescription: computed.description,
+      actionCount: actions.length,
+      actions: actions.map((a) => ({
+        date: a.actionDate,
+        code: a.actionCode,
+        type: a.type,
+        text: a.text,
+      })),
+    };
+  },
+});
+
+// A bill stores at most 250 actions (the sync fetches with limit=250).
+const MAX_BILL_ACTIONS = 250;
+const RECENT_ACTIONS_LIMIT = 20;
+
+/**
+ * Get a bill's most-recent actions (internal query, feeds the AI chatbot).
+ *
+ * Actions are stored newest-first (the sync deletes + re-inserts in the order
+ * the Library of Congress API returns them), so reading the index by
+ * `_creationTime` does NOT give chronological order — the previous
+ * `.order("desc").take(20)` returned the 20 *oldest* actions and the chatbot
+ * presented them as "Recent." We instead read the bounded set and sort by
+ * `actionDate` descending. The sort is stable, so actions sharing a date keep
+ * their stored order (the API's own newest-first ordering within a day).
  */
 export const getBillActions = internalQuery({
   args: { billId: v.string() },
@@ -81,10 +190,13 @@ export const getBillActions = internalQuery({
     const actions = await ctx.db
       .query("billActions")
       .withIndex("by_billId", (q) => q.eq("billId", args.billId))
-      .order("desc")
-      .take(20);
-    
-    return actions.map(a => ({
+      .take(MAX_BILL_ACTIONS);
+
+    const sorted = [...actions].sort((a, b) =>
+      a.actionDate < b.actionDate ? 1 : a.actionDate > b.actionDate ? -1 : 0,
+    );
+
+    return sorted.slice(0, RECENT_ACTIONS_LIMIT).map((a) => ({
       date: a.actionDate,
       description: a.text,
     }));
@@ -759,17 +871,6 @@ export const getCongressDashboard = query({
       statusBreakdown,
       topSponsors,
       topPolicyAreas,
-      partyBreakdown: [],
-      stateBreakdown: [],
-      timelineMetrics: [
-        { stage: "introduced", avgDays: 0, description: "Introduced" },
-        { stage: "committee", avgDays: 0, description: "To Committee" },
-        { stage: "passedOneChamber", avgDays: 0, description: "Passed One Chamber" },
-        { stage: "passedBothChambers", avgDays: 0, description: "Passed Both Chambers" },
-        { stage: "toPresident", avgDays: 0, description: "To President" },
-        { stage: "signed", avgDays: 0, description: "Signed by President" },
-        { stage: "law", avgDays: 0, description: "Became Law" },
-      ],
     };
   },
 });

--- a/convex/congressApi.ts
+++ b/convex/congressApi.ts
@@ -8,7 +8,30 @@ import {
   SYNC_SUMMARIES,
   SYNC_TEXT,
   SYNC_COMPLETE,
+  EXTRA_LEGISLATIVE_SUBJECTS,
+  EXTRA_TEXT_VERSIONS,
+  EXTRA_COMPLETE,
 } from "./sync";
+import { calculateBillStage } from "./billStage";
+import { Id } from "./_generated/dataModel";
+
+// Shape returned by internal.mutations.getBillBackfillPage. Declared explicitly
+// to break a TypeScript inference cycle through the `internal` API graph when
+// the backfill actions call the paginator.
+type BillBackfillPage = {
+  bills: Array<{
+    _id: Id<"bills">;
+    billId: string;
+    congress: number;
+    billType: string;
+    billNumber: string;
+    progressStage?: number;
+    progressDescription?: string;
+    extraSyncedBits: number;
+  }>;
+  isDone: boolean;
+  continueCursor: string;
+};
 
 const BASE_URL = "https://api.congress.gov/v3";
 const BATCH_SIZE = 50; // 50 bills per batch keeps well within Convex's 10-min action timeout
@@ -32,29 +55,6 @@ const BILL_TYPES = [
 // breakdown recomputes after each bill type finishes syncing.
 const HOUSE_TYPES_SET = new Set(["hr", "hjres", "hconres", "hres"]);
 
-// Bill stage constants
-const BillStages = {
-  INTRODUCED: 20,
-  IN_COMMITTEE: 40,
-  PASSED_ONE_CHAMBER: 60,
-  PASSED_BOTH_CHAMBERS: 80,
-  VETOED: 85,
-  TO_PRESIDENT: 90,
-  SIGNED_BY_PRESIDENT: 95,
-  BECAME_LAW: 100,
-} as const;
-
-const BillStageDescriptions: Record<number, string> = {
-  [BillStages.INTRODUCED]: "Introduced",
-  [BillStages.IN_COMMITTEE]: "In Committee",
-  [BillStages.PASSED_ONE_CHAMBER]: "Passed One Chamber",
-  [BillStages.PASSED_BOTH_CHAMBERS]: "Passed Both Chambers",
-  [BillStages.VETOED]: "Vetoed",
-  [BillStages.TO_PRESIDENT]: "To President",
-  [BillStages.SIGNED_BY_PRESIDENT]: "Signed by President",
-  [BillStages.BECAME_LAW]: "Became Law",
-};
-
 // Incremental sync constants
 const INCREMENTAL_LOOKBACK_HOURS = 26; // covers 24-hour cron + 2-hour buffer
 const FULL_SYNC_LOOKBACK_DAYS = 7; // weekly safety net catches anything missed
@@ -75,145 +75,21 @@ function getBillTypeLabel(type: string): string {
   return labels[type.toLowerCase()] || type;
 }
 
-/**
- * Calculate the bill's progress stage from its actions.
- * Ported from scripts/DataUpdate/updateBillInfo.ts
- */
-function calculateBillStage(actions: Array<{ text: string; type?: string; actionCode?: string }>): {
-  stage: number;
-  description: string;
-} {
-  let stage: number = BillStages.INTRODUCED;
-  let description =
-    BillStageDescriptions[BillStages.INTRODUCED];
-
-  if (!actions || !Array.isArray(actions) || actions.length === 0) {
-    return { stage, description };
-  }
-
-  let passedHouse = false;
-  let passedSenate = false;
-  let vetoed = false;
-  let toPresident = false;
-
-  // First pass: scan all actions to build a complete picture
-  for (const action of actions) {
-    const actionText = (action.text || "").toLowerCase();
-    const actionType = (action.type || "").toLowerCase();
-    const actionCode = action.actionCode || "";
-
-    // Check for law status first (highest priority)
-    if (
-      actionText.includes("became public law") ||
-      actionText.includes("became private law") ||
-      actionType === "becamelaw" ||
-      actionCode === "36000" ||
-      actionCode === "E40000"
-    ) {
-      return {
-        stage: BillStages.BECAME_LAW,
-        description: BillStageDescriptions[BillStages.BECAME_LAW],
-      };
-    }
-
-    // Check for presidential signature
-    if (
-      actionText.includes("signed by president") ||
-      actionType === "signedbypresident" ||
-      actionCode === "29000" ||
-      actionCode === "E30000"
-    ) {
-      return {
-        stage: BillStages.SIGNED_BY_PRESIDENT,
-        description: BillStageDescriptions[BillStages.SIGNED_BY_PRESIDENT],
-      };
-    }
-
-    // Check for veto (must be checked before "to president" to avoid early return)
-    if (
-      actionText.includes("vetoed") ||
-      actionText.includes("veto message") ||
-      actionType === "vetoed" ||
-      actionCode === "31000" ||
-      actionCode === "E50000"
-    ) {
-      vetoed = true;
-    }
-
-    // Check if sent to president
-    if (
-      actionText.includes("to president") ||
-      actionText.includes("presented to president") ||
-      actionCode === "28000" ||
-      actionCode === "E20000"
-    ) {
-      toPresident = true;
-    }
-
-    // Track passage through each chamber
-    if (
-      actionText.includes("passed house") ||
-      actionType === "passedhouse" ||
-      actionCode === "H32500"
-    ) {
-      passedHouse = true;
-    }
-    if (
-      actionText.includes("passed senate") ||
-      actionType === "passedsenate" ||
-      actionCode === "S32500"
-    ) {
-      passedSenate = true;
-    }
-
-    // Check for committee action
-    if (
-      actionText.includes("referred to") ||
-      actionText.includes("committee") ||
-      actionCode === "5000" ||
-      actionCode === "14000" ||
-      actionCode === "H11100" ||
-      actionCode === "S11100"
-    ) {
-      stage = BillStages.IN_COMMITTEE;
-      description = BillStageDescriptions[BillStages.IN_COMMITTEE];
-    }
-  }
-
-  // Determine final stage from flags (order matters: most advanced first)
-  if (vetoed) {
-    return {
-      stage: BillStages.VETOED,
-      description: BillStageDescriptions[BillStages.VETOED],
-    };
-  }
-
-  if (toPresident) {
-    return {
-      stage: BillStages.TO_PRESIDENT,
-      description: BillStageDescriptions[BillStages.TO_PRESIDENT],
-    };
-  }
-
-  if (passedHouse && passedSenate) {
-    return {
-      stage: BillStages.PASSED_BOTH_CHAMBERS,
-      description: BillStageDescriptions[BillStages.PASSED_BOTH_CHAMBERS],
-    };
-  }
-
-  if (passedHouse || passedSenate) {
-    return {
-      stage: BillStages.PASSED_ONE_CHAMBER,
-      description: BillStageDescriptions[BillStages.PASSED_ONE_CHAMBER],
-    };
-  }
-
-  return { stage, description };
-}
-
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Most recent value of the Congress.gov `x-ratelimit-remaining` response
+ * header, updated on every successful (non-429) fetch. The enrichment backfill
+ * reads this to throttle adaptively — pausing before it ever exhausts the
+ * 20,000-requests/hour budget rather than relying solely on 429 backoff.
+ * `null` until the first response carrying the header is seen.
+ */
+let lastRateLimitRemaining: number | null = null;
+
+export function getLastRateLimitRemaining(): number | null {
+  return lastRateLimitRemaining;
 }
 
 /**
@@ -249,9 +125,90 @@ async function fetchWithRetry(
       await delay(backoff);
       continue;
     }
+    const remaining = response.headers.get("x-ratelimit-remaining");
+    if (remaining !== null && remaining !== "") {
+      const parsed = Number(remaining);
+      if (!Number.isNaN(parsed)) lastRateLimitRemaining = parsed;
+    }
     return response;
   }
   return null;
+}
+
+type BillSubjectsResult = {
+  policyArea?: { name?: string; updateDate?: string };
+  legislativeSubjects: Array<{ name: string; updateDate?: string }>;
+};
+
+/**
+ * Fetch a bill's subjects, paginating the `legislativeSubjects` list (its
+ * `count` can exceed the 250-per-page limit; the original sync read only the
+ * first page's policy area and discarded the rest). Returns null only if the
+ * FIRST page fails; a later-page failure returns what was collected so far.
+ *
+ * The caller is expected to have just delayed before the first call, so page 0
+ * does not delay; subsequent pages delay between requests to respect the rate
+ * limit.
+ */
+async function fetchBillSubjects(
+  congress: number,
+  billType: string,
+  billNumber: number | string,
+  label: string,
+): Promise<BillSubjectsResult | null> {
+  const PAGE = 250;
+  const MAX_PAGES = 20; // 5,000 subjects — far beyond any real bill
+  let offset = 0;
+  let policyArea: { name?: string; updateDate?: string } | undefined;
+  const legislativeSubjects: Array<{ name: string; updateDate?: string }> = [];
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    if (page > 0) await delay(DELAY_BETWEEN_REQUESTS_MS);
+    const url = `${BASE_URL}/bill/${congress}/${billType}/${billNumber}/subjects?format=json&limit=${PAGE}&offset=${offset}`;
+    const resp = await fetchWithRetry(url, `${label} offset=${offset}`);
+    if (!resp || !resp.ok) {
+      if (page === 0) return null;
+      break;
+    }
+    const data = await resp.json();
+    if (policyArea === undefined && data.subjects?.policyArea) {
+      policyArea = data.subjects.policyArea;
+    }
+    const batch: Array<{ name?: string; updateDate?: string }> =
+      data.subjects?.legislativeSubjects ?? [];
+    for (const s of batch) {
+      if (s?.name) {
+        legislativeSubjects.push({ name: s.name, updateDate: s.updateDate });
+      }
+    }
+    if (batch.length < PAGE) break; // last page
+    offset += PAGE;
+  }
+  return { policyArea, legislativeSubjects };
+}
+
+/**
+ * Map the Library of Congress `textVersions` array to billText rows, pulling
+ * the PDF and Formatted Text URLs out of each version's `formats`.
+ */
+function textVersionsToRows(
+  textVersions: any[],
+): Array<{
+  date?: string;
+  formatsUrlPdf?: string;
+  formatsUrlTxt?: string;
+  type?: string;
+}> {
+  return (textVersions || []).map((v: any) => {
+    const pdf = v.formats?.find((f: any) => f.type === "PDF");
+    const txt = v.formats?.find((f: any) => f.type === "Formatted Text");
+    return {
+      date: v.date ?? undefined,
+      formatsUrlPdf: pdf?.url,
+      formatsUrlTxt: txt?.url,
+      type: v.type ?? undefined,
+    };
+  });
 }
 
 /**
@@ -336,6 +293,7 @@ export const syncBillBatch = internalAction({
 
       try {
         let endpointBits = 0;
+        let extraBits = 0;
 
         // 1. Fetch detailed bill info
         await delay(DELAY_BETWEEN_REQUESTS_MS);
@@ -415,22 +373,31 @@ export const syncBillBatch = internalAction({
           });
         }
 
-        // 3. Fetch and store subjects
+        // 3. Fetch and store subjects (policy area + ALL legislative subjects)
         await delay(DELAY_BETWEEN_REQUESTS_MS);
         try {
-          const subjectsUrl = `${BASE_URL}/bill/${args.congress}/${args.billType}/${bill.number}/subjects?format=json`;
-          const subjectsResponse = await fetchWithRetry(subjectsUrl, `subjects ${billId}`);
-          if (subjectsResponse && subjectsResponse.ok) {
+          const subjects = await fetchBillSubjects(
+            args.congress,
+            args.billType,
+            bill.number,
+            `subjects ${billId}`,
+          );
+          if (subjects) {
             endpointBits |= SYNC_SUBJECTS;
-            const subjectsData = await subjectsResponse.json();
-            const policyArea = subjectsData.subjects?.policyArea;
-            if (policyArea) {
+            if (subjects.policyArea) {
               await ctx.runMutation(internal.mutations.upsertBillSubject, {
                 billId,
-                policyAreaName: policyArea.name,
-                policyAreaUpdateDate: policyArea.updateDate,
+                policyAreaName: subjects.policyArea.name,
+                policyAreaUpdateDate: subjects.policyArea.updateDate,
               });
             }
+            // Replace-all, even when empty (a legitimately-empty list is a
+            // valid "fully synced" state for minor bills).
+            await ctx.runMutation(
+              internal.mutations.replaceBillLegislativeSubjects,
+              { billId, subjects: subjects.legislativeSubjects },
+            );
+            extraBits |= EXTRA_LEGISLATIVE_SUBJECTS;
           }
         } catch {
           // Non-critical
@@ -460,7 +427,7 @@ export const syncBillBatch = internalAction({
           // Non-critical
         }
 
-        // 5. Fetch and store text/PDF info
+        // 5. Fetch and store text/PDF info (ALL versions, replace-all)
         await delay(DELAY_BETWEEN_REQUESTS_MS);
         try {
           const textUrl = `${BASE_URL}/bill/${args.congress}/${args.billType}/${bill.number}/text?format=json`;
@@ -468,23 +435,11 @@ export const syncBillBatch = internalAction({
           if (textResponse && textResponse.ok) {
             endpointBits |= SYNC_TEXT;
             const textData = await textResponse.json();
-            const textVersions = textData.textVersions || [];
-            if (textVersions.length > 0) {
-              const latest = textVersions[textVersions.length - 1];
-              const pdfFormat = latest.formats?.find(
-                (f: any) => f.type === "PDF"
-              );
-              const txtFormat = latest.formats?.find(
-                (f: any) => f.type === "Formatted Text"
-              );
-              await ctx.runMutation(internal.mutations.upsertBillText, {
-                billId,
-                date: latest.date,
-                formatsUrlPdf: pdfFormat?.url,
-                formatsUrlTxt: txtFormat?.url,
-                type: latest.type,
-              });
-            }
+            await ctx.runMutation(internal.mutations.replaceBillTextVersions, {
+              billId,
+              versions: textVersionsToRows(textData.textVersions || []),
+            });
+            extraBits |= EXTRA_TEXT_VERSIONS;
           }
         } catch {
           // Non-critical
@@ -496,6 +451,14 @@ export const syncBillBatch = internalAction({
           endpointBits,
           lastSyncAttempt: new Date().toISOString(),
         });
+
+        // Track enrichment progress separately (subjects + text versions).
+        if (extraBits > 0) {
+          await ctx.runMutation(internal.mutations.setBillExtraSyncedBits, {
+            billId,
+            bits: extraBits,
+          });
+        }
 
         successCount++;
       } catch (error: any) {
@@ -1030,6 +993,287 @@ export const backfillSyncStatus = internalAction({
     }
 
     return { processed: toBackfill.length, remaining: toBackfill.length >= BACKFILL_BATCH_SIZE };
+  },
+});
+
+const STAGE_BACKFILL_PAGE = 40; // bills per mutation (≤250 actions each → read-limit safe)
+const STAGE_BACKFILL_BILLS_PER_RUN = 5000; // bills per invocation before self-scheduling
+
+/**
+ * Re-derive the progress stage for ALL existing bills from their stored
+ * actions, using the corrected calculator (no API calls). Patches only bills
+ * whose stage changed; the trigger-wrapped mutation keeps the aggregates in
+ * sync. Self-schedules across batches and, on completion, refreshes the
+ * precomputed homepage stats (Part 1c). Idempotent and safe to re-run.
+ *
+ * Run from the CLI: `npx convex run congressApi:backfillBillStages '{}'`.
+ */
+export const backfillBillStages = internalAction({
+  args: { cursor: v.optional(v.union(v.string(), v.null())) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ done: boolean; processedThisRun: number; changedThisRun: number }> => {
+    let cursor: string | null = args.cursor ?? null;
+    let processedThisRun = 0;
+    let changedThisRun = 0;
+
+    for (;;) {
+      const page: BillBackfillPage = await ctx.runQuery(internal.mutations.getBillBackfillPage, {
+        cursor,
+        numItems: STAGE_BACKFILL_PAGE,
+      });
+
+      if (page.bills.length > 0) {
+        const { changed } = await ctx.runMutation(
+          internal.mutations.rederiveStagesForBills,
+          {
+            bills: page.bills.map((b) => ({
+              _id: b._id,
+              billId: b.billId,
+              progressStage: b.progressStage,
+              progressDescription: b.progressDescription,
+            })),
+          },
+        );
+        changedThisRun += changed;
+        processedThisRun += page.bills.length;
+      }
+
+      if (page.isDone) {
+        console.log(
+          `backfillBillStages: pass complete, ${changedThisRun} stages changed this run; refreshing rollups`,
+        );
+        // Part 1c: refresh precomputed homepage stats so corrected stages show.
+        await ctx.scheduler.runAfter(0, internal.congressApi.recomputeAllStats, {});
+        return { done: true, processedThisRun, changedThisRun };
+      }
+
+      cursor = page.continueCursor;
+
+      if (processedThisRun >= STAGE_BACKFILL_BILLS_PER_RUN) {
+        await ctx.scheduler.runAfter(
+          1000,
+          internal.congressApi.backfillBillStages,
+          { cursor },
+        );
+        console.log(
+          `backfillBillStages: processed ${processedThisRun} (changed ${changedThisRun}); scheduled continuation`,
+        );
+        return { done: false, processedThisRun, changedThisRun };
+      }
+    }
+  },
+});
+
+const ENRICHMENT_PAGE = 100; // bills scanned per page (already-done bills skip cheaply)
+const ENRICHMENT_DELAY_MS = 350; // per API call
+const ENRICHMENT_RATE_FLOOR = 3000; // pause when x-ratelimit-remaining drops below this
+const ENRICHMENT_MAX_RUN_MS = 8 * 60 * 1000; // 8 min — margin before the 10-min action kill
+const ENRICHMENT_COOLDOWN_MS = 15 * 60 * 1000; // wait when the rate floor is hit
+const ENRICHMENT_RESCHEDULE_MS = 2000; // gap between self-scheduled continuations
+
+/**
+ * Managed historical backfill of the richer LoC data that the original sync
+ * discarded: all legislative subjects (paginated) and all text versions. Visits
+ * each bill missing an enrichment bit and fetches only the endpoints it needs,
+ * marking progress via `extraSyncedBits` so it always resumes where it stopped
+ * and no-ops once everything is stored.
+ *
+ * "Never hit the limit": a ~350ms per-call delay holds throughput near
+ * ~10k req/hr (half the 20k/hr cap), and an adaptive throttle pauses for a
+ * cooldown the moment the live `x-ratelimit-remaining` header drops below a
+ * safety floor. Each invocation stops after ~8 minutes (well under the 10-min
+ * action limit) and self-schedules a continuation.
+ *
+ * Run from the CLI: `npx convex run congressApi:backfillBillEnrichment '{}'`.
+ */
+export const backfillBillEnrichment = internalAction({
+  args: { cursor: v.optional(v.union(v.string(), v.null())) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    done: boolean;
+    enrichedThisRun: number;
+    pausedForRateLimit: boolean;
+  }> => {
+    const apiKey = process.env.CONGRESS_API_KEY;
+    if (!apiKey) throw new Error("CONGRESS_API_KEY not configured");
+
+    const startedAt = Date.now();
+    let cursor: string | null = args.cursor ?? null;
+    let enrichedThisRun = 0;
+
+    for (;;) {
+      const page: BillBackfillPage = await ctx.runQuery(internal.mutations.getBillBackfillPage, {
+        cursor,
+        numItems: ENRICHMENT_PAGE,
+      });
+
+      for (const bill of page.bills) {
+        const needsSubjects =
+          (bill.extraSyncedBits & EXTRA_LEGISLATIVE_SUBJECTS) === 0;
+        const needsText = (bill.extraSyncedBits & EXTRA_TEXT_VERSIONS) === 0;
+        if (!needsSubjects && !needsText) continue;
+
+        // Adaptive throttle: bail before exhausting the hourly budget. Resume
+        // from the current page cursor (already-done bills skip on re-run).
+        if (
+          lastRateLimitRemaining !== null &&
+          lastRateLimitRemaining < ENRICHMENT_RATE_FLOOR
+        ) {
+          console.warn(
+            `backfillBillEnrichment: rate-limit floor hit (${lastRateLimitRemaining} remaining); cooling down`,
+          );
+          await ctx.scheduler.runAfter(
+            ENRICHMENT_COOLDOWN_MS,
+            internal.congressApi.backfillBillEnrichment,
+            { cursor },
+          );
+          return { done: false, enrichedThisRun, pausedForRateLimit: true };
+        }
+
+        let bits = 0;
+
+        if (needsSubjects) {
+          await delay(ENRICHMENT_DELAY_MS);
+          const subjects = await fetchBillSubjects(
+            bill.congress,
+            bill.billType,
+            bill.billNumber,
+            `enrich subjects ${bill.billId}`,
+          );
+          if (subjects) {
+            if (subjects.policyArea) {
+              await ctx.runMutation(internal.mutations.upsertBillSubject, {
+                billId: bill.billId,
+                policyAreaName: subjects.policyArea.name,
+                policyAreaUpdateDate: subjects.policyArea.updateDate,
+              });
+            }
+            await ctx.runMutation(
+              internal.mutations.replaceBillLegislativeSubjects,
+              { billId: bill.billId, subjects: subjects.legislativeSubjects },
+            );
+            bits |= EXTRA_LEGISLATIVE_SUBJECTS;
+          }
+        }
+
+        if (needsText) {
+          await delay(ENRICHMENT_DELAY_MS);
+          const textUrl = `${BASE_URL}/bill/${bill.congress}/${bill.billType}/${bill.billNumber}/text?format=json`;
+          const resp = await fetchWithRetry(textUrl, `enrich text ${bill.billId}`);
+          if (resp && resp.ok) {
+            const data = await resp.json();
+            await ctx.runMutation(internal.mutations.replaceBillTextVersions, {
+              billId: bill.billId,
+              versions: textVersionsToRows(data.textVersions || []),
+            });
+            bits |= EXTRA_TEXT_VERSIONS;
+          }
+        }
+
+        if (bits > 0) {
+          await ctx.runMutation(internal.mutations.setBillExtraSyncedBits, {
+            billId: bill.billId,
+            bits,
+          });
+          enrichedThisRun++;
+        }
+
+        if (Date.now() - startedAt > ENRICHMENT_MAX_RUN_MS) {
+          await ctx.scheduler.runAfter(
+            ENRICHMENT_RESCHEDULE_MS,
+            internal.congressApi.backfillBillEnrichment,
+            { cursor },
+          );
+          console.log(
+            `backfillBillEnrichment: time budget reached, enriched ${enrichedThisRun}; scheduled continuation`,
+          );
+          return { done: false, enrichedThisRun, pausedForRateLimit: false };
+        }
+      }
+
+      if (page.isDone) {
+        console.log(
+          `backfillBillEnrichment: full pass complete, enriched ${enrichedThisRun} this run`,
+        );
+        return { done: true, enrichedThisRun, pausedForRateLimit: false };
+      }
+      cursor = page.continueCursor;
+    }
+  },
+});
+
+/**
+ * Verification query for the enrichment backfill: per-congress counts of bills
+ * still missing legislative subjects / text versions, plus the global total
+ * remaining. Watch `remaining` trend to 0.
+ *
+ * Run from the CLI: `npx convex run congressApi:backfillEnrichmentStatus '{}'`.
+ */
+export const backfillEnrichmentStatus = internalAction({
+  args: {},
+  handler: async (
+    ctx,
+  ): Promise<{
+    total: number;
+    remaining: number;
+    byCongress: Array<{
+      congress: number;
+      total: number;
+      missingSubjects: number;
+      missingText: number;
+      complete: number;
+    }>;
+  }> => {
+    let cursor: string | null = null;
+    let total = 0;
+    let remaining = 0;
+    const perCongress = new Map<
+      number,
+      {
+        total: number;
+        missingSubjects: number;
+        missingText: number;
+        complete: number;
+      }
+    >();
+
+    for (;;) {
+      const page: BillBackfillPage = await ctx.runQuery(internal.mutations.getBillBackfillPage, {
+        cursor,
+        numItems: 2000,
+      });
+      for (const b of page.bills) {
+        total++;
+        const row =
+          perCongress.get(b.congress) ??
+          { total: 0, missingSubjects: 0, missingText: 0, complete: 0 };
+        row.total++;
+        if ((b.extraSyncedBits & EXTRA_LEGISLATIVE_SUBJECTS) === 0)
+          row.missingSubjects++;
+        if ((b.extraSyncedBits & EXTRA_TEXT_VERSIONS) === 0) row.missingText++;
+        if ((b.extraSyncedBits & EXTRA_COMPLETE) === EXTRA_COMPLETE) {
+          row.complete++;
+        } else {
+          remaining++;
+        }
+        perCongress.set(b.congress, row);
+      }
+      if (page.isDone) break;
+      cursor = page.continueCursor;
+    }
+
+    const byCongress = [...perCongress.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([congress, row]) => ({ congress, ...row }));
+
+    console.log(
+      `backfillEnrichmentStatus: total=${total}, remaining=${remaining}`,
+    );
+    return { total, remaining, byCongress };
   },
 });
 

--- a/convex/congressApi.ts
+++ b/convex/congressApi.ts
@@ -110,7 +110,26 @@ async function fetchWithRetry(
   }
   const init = { headers: { "X-Api-Key": apiKey } };
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const response = await fetch(url, init);
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (err: any) {
+      // Transient network failure (e.g. "TypeError: fetch failed" — a dropped
+      // connection). Treat like a retryable error so a single blip never kills
+      // a long-running backfill mid-flight.
+      if (attempt === MAX_RETRIES) {
+        console.error(
+          `Network error on ${label} after ${MAX_RETRIES + 1} attempts (${err?.message ?? err}), giving up`
+        );
+        return null;
+      }
+      const backoff = RATE_LIMIT_BACKOFF_MS * Math.pow(2, attempt);
+      console.warn(
+        `Network error on ${label} (${err?.message ?? err}), retrying in ${backoff / 1000}s (attempt ${attempt + 1}/${MAX_RETRIES})`
+      );
+      await delay(backoff);
+      continue;
+    }
     if (response.status === 429) {
       if (attempt === MAX_RETRIES) {
         console.error(
@@ -1086,10 +1105,21 @@ const ENRICHMENT_RESCHEDULE_MS = 2000; // gap between self-scheduled continuatio
  * safety floor. Each invocation stops after ~8 minutes (well under the 10-min
  * action limit) and self-schedules a continuation.
  *
+ * Resilient by design: transient per-bill failures are caught and skipped
+ * (the bill keeps its missing bit and is retried on a later pass), and on
+ * reaching the end the action starts a fresh pass whenever the previous pass
+ * enriched at least one bill — so anything skipped due to a network blip is
+ * picked up automatically. The loop stops once a full pass enriches nothing.
+ *
  * Run from the CLI: `npx convex run congressApi:backfillBillEnrichment '{}'`.
  */
 export const backfillBillEnrichment = internalAction({
-  args: { cursor: v.optional(v.union(v.string(), v.null())) },
+  args: {
+    cursor: v.optional(v.union(v.string(), v.null())),
+    // Bills enriched so far in the CURRENT pass (threaded across the pass's
+    // self-scheduled invocations). Used to decide whether to start another pass.
+    passEnriched: v.optional(v.number()),
+  },
   handler: async (
     ctx,
     args,
@@ -1103,6 +1133,7 @@ export const backfillBillEnrichment = internalAction({
 
     const startedAt = Date.now();
     let cursor: string | null = args.cursor ?? null;
+    let passEnriched = args.passEnriched ?? 0;
     let enrichedThisRun = 0;
 
     for (;;) {
@@ -1129,75 +1160,98 @@ export const backfillBillEnrichment = internalAction({
           await ctx.scheduler.runAfter(
             ENRICHMENT_COOLDOWN_MS,
             internal.congressApi.backfillBillEnrichment,
-            { cursor },
+            { cursor, passEnriched },
           );
           return { done: false, enrichedThisRun, pausedForRateLimit: true };
         }
 
-        let bits = 0;
+        // Per-bill work is isolated: a thrown error (network blip, bad JSON)
+        // skips just this bill — it keeps its missing bit and is retried later.
+        try {
+          let bits = 0;
 
-        if (needsSubjects) {
-          await delay(ENRICHMENT_DELAY_MS);
-          const subjects = await fetchBillSubjects(
-            bill.congress,
-            bill.billType,
-            bill.billNumber,
-            `enrich subjects ${bill.billId}`,
-          );
-          if (subjects) {
-            if (subjects.policyArea) {
-              await ctx.runMutation(internal.mutations.upsertBillSubject, {
-                billId: bill.billId,
-                policyAreaName: subjects.policyArea.name,
-                policyAreaUpdateDate: subjects.policyArea.updateDate,
-              });
-            }
-            await ctx.runMutation(
-              internal.mutations.replaceBillLegislativeSubjects,
-              { billId: bill.billId, subjects: subjects.legislativeSubjects },
+          if (needsSubjects) {
+            await delay(ENRICHMENT_DELAY_MS);
+            const subjects = await fetchBillSubjects(
+              bill.congress,
+              bill.billType,
+              bill.billNumber,
+              `enrich subjects ${bill.billId}`,
             );
-            bits |= EXTRA_LEGISLATIVE_SUBJECTS;
+            if (subjects) {
+              if (subjects.policyArea) {
+                await ctx.runMutation(internal.mutations.upsertBillSubject, {
+                  billId: bill.billId,
+                  policyAreaName: subjects.policyArea.name,
+                  policyAreaUpdateDate: subjects.policyArea.updateDate,
+                });
+              }
+              await ctx.runMutation(
+                internal.mutations.replaceBillLegislativeSubjects,
+                { billId: bill.billId, subjects: subjects.legislativeSubjects },
+              );
+              bits |= EXTRA_LEGISLATIVE_SUBJECTS;
+            }
           }
-        }
 
-        if (needsText) {
-          await delay(ENRICHMENT_DELAY_MS);
-          const textUrl = `${BASE_URL}/bill/${bill.congress}/${bill.billType}/${bill.billNumber}/text?format=json`;
-          const resp = await fetchWithRetry(textUrl, `enrich text ${bill.billId}`);
-          if (resp && resp.ok) {
-            const data = await resp.json();
-            await ctx.runMutation(internal.mutations.replaceBillTextVersions, {
+          if (needsText) {
+            await delay(ENRICHMENT_DELAY_MS);
+            const textUrl = `${BASE_URL}/bill/${bill.congress}/${bill.billType}/${bill.billNumber}/text?format=json`;
+            const resp = await fetchWithRetry(textUrl, `enrich text ${bill.billId}`);
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              await ctx.runMutation(internal.mutations.replaceBillTextVersions, {
+                billId: bill.billId,
+                versions: textVersionsToRows(data.textVersions || []),
+              });
+              bits |= EXTRA_TEXT_VERSIONS;
+            }
+          }
+
+          if (bits > 0) {
+            await ctx.runMutation(internal.mutations.setBillExtraSyncedBits, {
               billId: bill.billId,
-              versions: textVersionsToRows(data.textVersions || []),
+              bits,
             });
-            bits |= EXTRA_TEXT_VERSIONS;
+            enrichedThisRun++;
+            passEnriched++;
           }
-        }
-
-        if (bits > 0) {
-          await ctx.runMutation(internal.mutations.setBillExtraSyncedBits, {
-            billId: bill.billId,
-            bits,
-          });
-          enrichedThisRun++;
+        } catch (err: any) {
+          console.error(
+            `backfillBillEnrichment: skipping ${bill.billId} after error: ${err?.message ?? err}`,
+          );
         }
 
         if (Date.now() - startedAt > ENRICHMENT_MAX_RUN_MS) {
           await ctx.scheduler.runAfter(
             ENRICHMENT_RESCHEDULE_MS,
             internal.congressApi.backfillBillEnrichment,
-            { cursor },
+            { cursor, passEnriched },
           );
           console.log(
-            `backfillBillEnrichment: time budget reached, enriched ${enrichedThisRun}; scheduled continuation`,
+            `backfillBillEnrichment: time budget reached, enriched ${enrichedThisRun} (pass ${passEnriched}); scheduled continuation`,
           );
           return { done: false, enrichedThisRun, pausedForRateLimit: false };
         }
       }
 
       if (page.isDone) {
+        // Self-heal: if this pass enriched anything, run another full pass to
+        // pick up bills that were skipped due to transient errors. A pass that
+        // enriches nothing means everything reachable is done — stop.
+        if (passEnriched > 0) {
+          console.log(
+            `backfillBillEnrichment: pass complete (enriched ${passEnriched}); starting another pass to catch any skipped bills`,
+          );
+          await ctx.scheduler.runAfter(
+            ENRICHMENT_RESCHEDULE_MS,
+            internal.congressApi.backfillBillEnrichment,
+            { cursor: null, passEnriched: 0 },
+          );
+          return { done: false, enrichedThisRun, pausedForRateLimit: false };
+        }
         console.log(
-          `backfillBillEnrichment: full pass complete, enriched ${enrichedThisRun} this run`,
+          `backfillBillEnrichment: complete — a full pass enriched 0 bills`,
         );
         return { done: true, enrichedThisRun, pausedForRateLimit: false };
       }

--- a/convex/congressApi.ts
+++ b/convex/congressApi.ts
@@ -1,4 +1,5 @@
 import { internalAction, internalMutation } from "./_generated/server";
+import type { ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import {
@@ -27,6 +28,7 @@ type BillBackfillPage = {
     billNumber: string;
     progressStage?: number;
     progressDescription?: string;
+    latestActionDate?: string;
     extraSyncedBits: number;
   }>;
   isDone: boolean;
@@ -40,6 +42,12 @@ const MAX_RETRIES = 3; // max retries per API call on rate limit
 const RATE_LIMIT_BACKOFF_MS = 10000; // initial backoff on 429 (10s), doubles each retry
 const CONSECUTIVE_FAIL_LIMIT = 5; // abort batch after this many consecutive failures
 const RATE_LIMIT_RESUME_DELAY_MS = 300000; // 5 min backoff before resuming after circuit breaker
+// Proactive floor on the live x-ratelimit-remaining header. When a heavy
+// re-pull or reconciliation drives the remaining hourly budget below this, the
+// batch pauses and resumes after a cooldown rather than starving the daily
+// incremental sync. Set below the enrichment backfill's floor (3000) so the
+// small daily sync keeps comfortable headroom.
+const SYNC_RATE_FLOOR = 2000;
 const BILL_TYPES = [
   "hr",
   "s",
@@ -231,6 +239,193 @@ function textVersionsToRows(
 }
 
 /**
+ * Sync a single bill end-to-end and persist everything the batch sync does:
+ * detail, actions + derived stage, subjects (policy area + ALL legislative
+ * subjects), summaries, ALL text versions, the endpoint sync-status bitmask and
+ * the enrichment bitmask. Extracted verbatim from syncBillBatch's per-bill loop
+ * body so it can be reused for targeted single-bill remediation
+ * (syncOneBill / reconcileMissingBills).
+ *
+ * Returns `{ detailOk }`: the detail fetch is the only critical call (everything
+ * else is best-effort and non-fatal). The caller owns batch-level accounting
+ * (success/fail counters, circuit breaker). Behavior-preserving: a thrown error
+ * propagates to the caller exactly as the original inline body did.
+ */
+async function syncSingleBill(
+  ctx: ActionCtx,
+  congress: number,
+  billType: string,
+  billNumber: number | string,
+): Promise<{ detailOk: boolean }> {
+  const billId = `${billNumber}${billType}${congress}`;
+  let endpointBits = 0;
+  let extraBits = 0;
+
+  // 1. Fetch detailed bill info
+  await delay(DELAY_BETWEEN_REQUESTS_MS);
+  const detailUrl = `${BASE_URL}/bill/${congress}/${billType}/${billNumber}?format=json`;
+  const detailResponse = await fetchWithRetry(detailUrl, `detail ${billId}`);
+
+  if (!detailResponse || !detailResponse.ok) {
+    console.error(
+      `Failed to fetch detail for ${billId}: ${detailResponse ? detailResponse.statusText : "rate limit exhausted"}`
+    );
+    return { detailOk: false };
+  }
+
+  endpointBits |= SYNC_DETAIL;
+
+  const detailData = await detailResponse.json();
+  const billDetail = detailData.bill;
+
+  // 2. Fetch actions to calculate progress stage
+  await delay(DELAY_BETWEEN_REQUESTS_MS);
+  let actions: any[] = [];
+  try {
+    const actionsUrl = `${BASE_URL}/bill/${congress}/${billType}/${billNumber}/actions?format=json&limit=250`;
+    const actionsResponse = await fetchWithRetry(actionsUrl, `actions ${billId}`);
+    if (actionsResponse && actionsResponse.ok) {
+      const actionsData = await actionsResponse.json();
+      actions = actionsData.actions || [];
+      endpointBits |= SYNC_ACTIONS;
+    }
+  } catch {
+    // Actions fetch failure is non-critical
+  }
+
+  const { stage, description } = calculateBillStage(actions);
+
+  // Remove number prefix from title
+  const titleWithoutNumber =
+    billDetail.title?.replace(
+      /^(H\.R\.|S\.|H\.J\.Res\.|S\.J\.Res\.|H\.Con\.Res\.|S\.Con\.Res\.|H\.Res\.|S\.Res\.)\s*\d+\s*[-–]\s*/,
+      ""
+    ) || "";
+
+  // Upsert the bill
+  await ctx.runMutation(internal.mutations.upsertBill, {
+    billId,
+    congress,
+    billType,
+    billNumber: billNumber.toString(),
+    billTypeLabel: getBillTypeLabel(billType),
+    title: billDetail.title || "",
+    titleWithoutNumber,
+    introducedDate: billDetail.introducedDate || "",
+    sponsorFirstName: billDetail.sponsors?.[0]?.firstName,
+    sponsorLastName: billDetail.sponsors?.[0]?.lastName,
+    sponsorParty: billDetail.sponsors?.[0]?.party,
+    sponsorState: billDetail.sponsors?.[0]?.state,
+    progressStage: stage,
+    progressDescription: description,
+  });
+
+  // Store actions
+  if (actions.length > 0) {
+    await ctx.runMutation(internal.mutations.upsertBillActions, {
+      billId,
+      actions: actions.map((a: any) => ({
+        actionCode: a.actionCode || undefined,
+        actionDate: a.actionDate || "",
+        sourceSystemCode: a.sourceSystem?.code,
+        sourceSystemName: a.sourceSystem?.name,
+        text: a.text || "",
+        type: a.type || undefined,
+      })),
+    });
+  }
+
+  // 3. Fetch and store subjects (policy area + ALL legislative subjects)
+  await delay(DELAY_BETWEEN_REQUESTS_MS);
+  try {
+    const subjects = await fetchBillSubjects(
+      congress,
+      billType,
+      billNumber,
+      `subjects ${billId}`,
+    );
+    if (subjects) {
+      endpointBits |= SYNC_SUBJECTS;
+      if (subjects.policyArea) {
+        await ctx.runMutation(internal.mutations.upsertBillSubject, {
+          billId,
+          policyAreaName: subjects.policyArea.name,
+          policyAreaUpdateDate: subjects.policyArea.updateDate,
+        });
+      }
+      // Replace-all, even when empty (a legitimately-empty list is a
+      // valid "fully synced" state for minor bills).
+      await ctx.runMutation(
+        internal.mutations.replaceBillLegislativeSubjects,
+        { billId, subjects: subjects.legislativeSubjects },
+      );
+      extraBits |= EXTRA_LEGISLATIVE_SUBJECTS;
+    }
+  } catch {
+    // Non-critical
+  }
+
+  // 4. Fetch and store summaries
+  await delay(DELAY_BETWEEN_REQUESTS_MS);
+  try {
+    const summariesUrl = `${BASE_URL}/bill/${congress}/${billType}/${billNumber}/summaries?format=json`;
+    const summariesResponse = await fetchWithRetry(summariesUrl, `summaries ${billId}`);
+    if (summariesResponse && summariesResponse.ok) {
+      endpointBits |= SYNC_SUMMARIES;
+      const summariesData = await summariesResponse.json();
+      const summaries = summariesData.summaries || [];
+      for (const summary of summaries) {
+        await ctx.runMutation(internal.mutations.upsertBillSummary, {
+          billId,
+          actionDate: summary.actionDate,
+          actionDesc: summary.actionDesc,
+          text: summary.text || "",
+          updateDate: summary.updateDate || new Date().toISOString(),
+          versionCode: summary.versionCode,
+        });
+      }
+    }
+  } catch {
+    // Non-critical
+  }
+
+  // 5. Fetch and store text/PDF info (ALL versions, replace-all)
+  await delay(DELAY_BETWEEN_REQUESTS_MS);
+  try {
+    const textUrl = `${BASE_URL}/bill/${congress}/${billType}/${billNumber}/text?format=json`;
+    const textResponse = await fetchWithRetry(textUrl, `text ${billId}`);
+    if (textResponse && textResponse.ok) {
+      endpointBits |= SYNC_TEXT;
+      const textData = await textResponse.json();
+      await ctx.runMutation(internal.mutations.replaceBillTextVersions, {
+        billId,
+        versions: textVersionsToRows(textData.textVersions || []),
+      });
+      extraBits |= EXTRA_TEXT_VERSIONS;
+    }
+  } catch {
+    // Non-critical
+  }
+
+  // Track which endpoints succeeded for this bill
+  await ctx.runMutation(internal.mutations.updateBillSyncStatus, {
+    billId,
+    endpointBits,
+    lastSyncAttempt: new Date().toISOString(),
+  });
+
+  // Track enrichment progress separately (subjects + text versions).
+  if (extraBits > 0) {
+    await ctx.runMutation(internal.mutations.setBillExtraSyncedBits, {
+      billId,
+      bits: extraBits,
+    });
+  }
+
+  return { detailOk: true };
+}
+
+/**
  * Fetch a batch of bills for a congress/type and schedule the next batch.
  * Uses ctx.scheduler.runAfter to chain batches (handles 10-min action timeout).
  */
@@ -310,175 +505,34 @@ export const syncBillBatch = internalAction({
         break;
       }
 
+      // Proactive rate-limit floor: if the live remaining-budget header has
+      // dropped below the floor, pause and resume after a cooldown (reusing the
+      // circuit-breaker reschedule below) rather than starving the daily sync.
+      if (
+        lastRateLimitRemaining !== null &&
+        lastRateLimitRemaining < SYNC_RATE_FLOOR
+      ) {
+        console.warn(
+          `Rate-limit floor hit (${lastRateLimitRemaining} remaining); pausing ${args.billType} batch at offset ${args.offset}`
+        );
+        rateLimitAborted = true;
+        break;
+      }
+
       try {
-        let endpointBits = 0;
-        let extraBits = 0;
-
-        // 1. Fetch detailed bill info
-        await delay(DELAY_BETWEEN_REQUESTS_MS);
-        const detailUrl = `${BASE_URL}/bill/${args.congress}/${args.billType}/${bill.number}?format=json`;
-        const detailResponse = await fetchWithRetry(detailUrl, `detail ${billId}`);
-
-        if (!detailResponse || !detailResponse.ok) {
-          console.error(
-            `Failed to fetch detail for ${billId}: ${detailResponse ? detailResponse.statusText : "rate limit exhausted"}`
-          );
+        const { detailOk } = await syncSingleBill(
+          ctx,
+          args.congress,
+          args.billType,
+          bill.number,
+        );
+        if (!detailOk) {
           failCount++;
           consecutiveFailures++;
           continue;
         }
-
-        // Reset consecutive failures on successful detail fetch
+        // Reset consecutive failures on a successful (detail-fetched) bill.
         consecutiveFailures = 0;
-        endpointBits |= SYNC_DETAIL;
-
-        const detailData = await detailResponse.json();
-        const billDetail = detailData.bill;
-
-        // 2. Fetch actions to calculate progress stage
-        await delay(DELAY_BETWEEN_REQUESTS_MS);
-        let actions: any[] = [];
-        try {
-          const actionsUrl = `${BASE_URL}/bill/${args.congress}/${args.billType}/${bill.number}/actions?format=json&limit=250`;
-          const actionsResponse = await fetchWithRetry(actionsUrl, `actions ${billId}`);
-          if (actionsResponse && actionsResponse.ok) {
-            const actionsData = await actionsResponse.json();
-            actions = actionsData.actions || [];
-            endpointBits |= SYNC_ACTIONS;
-          }
-        } catch {
-          // Actions fetch failure is non-critical
-        }
-
-        const { stage, description } = calculateBillStage(actions);
-
-        // Remove number prefix from title
-        const titleWithoutNumber =
-          billDetail.title?.replace(
-            /^(H\.R\.|S\.|H\.J\.Res\.|S\.J\.Res\.|H\.Con\.Res\.|S\.Con\.Res\.|H\.Res\.|S\.Res\.)\s*\d+\s*[-–]\s*/,
-            ""
-          ) || "";
-
-        // Upsert the bill
-        await ctx.runMutation(internal.mutations.upsertBill, {
-          billId,
-          congress: args.congress,
-          billType: args.billType,
-          billNumber: bill.number.toString(),
-          billTypeLabel: getBillTypeLabel(args.billType),
-          title: billDetail.title || "",
-          titleWithoutNumber,
-          introducedDate: billDetail.introducedDate || "",
-          sponsorFirstName: billDetail.sponsors?.[0]?.firstName,
-          sponsorLastName: billDetail.sponsors?.[0]?.lastName,
-          sponsorParty: billDetail.sponsors?.[0]?.party,
-          sponsorState: billDetail.sponsors?.[0]?.state,
-          progressStage: stage,
-          progressDescription: description,
-        });
-
-        // Store actions
-        if (actions.length > 0) {
-          await ctx.runMutation(internal.mutations.upsertBillActions, {
-            billId,
-            actions: actions.map((a: any) => ({
-              actionCode: a.actionCode || undefined,
-              actionDate: a.actionDate || "",
-              sourceSystemCode: a.sourceSystem?.code,
-              sourceSystemName: a.sourceSystem?.name,
-              text: a.text || "",
-              type: a.type || undefined,
-            })),
-          });
-        }
-
-        // 3. Fetch and store subjects (policy area + ALL legislative subjects)
-        await delay(DELAY_BETWEEN_REQUESTS_MS);
-        try {
-          const subjects = await fetchBillSubjects(
-            args.congress,
-            args.billType,
-            bill.number,
-            `subjects ${billId}`,
-          );
-          if (subjects) {
-            endpointBits |= SYNC_SUBJECTS;
-            if (subjects.policyArea) {
-              await ctx.runMutation(internal.mutations.upsertBillSubject, {
-                billId,
-                policyAreaName: subjects.policyArea.name,
-                policyAreaUpdateDate: subjects.policyArea.updateDate,
-              });
-            }
-            // Replace-all, even when empty (a legitimately-empty list is a
-            // valid "fully synced" state for minor bills).
-            await ctx.runMutation(
-              internal.mutations.replaceBillLegislativeSubjects,
-              { billId, subjects: subjects.legislativeSubjects },
-            );
-            extraBits |= EXTRA_LEGISLATIVE_SUBJECTS;
-          }
-        } catch {
-          // Non-critical
-        }
-
-        // 4. Fetch and store summaries
-        await delay(DELAY_BETWEEN_REQUESTS_MS);
-        try {
-          const summariesUrl = `${BASE_URL}/bill/${args.congress}/${args.billType}/${bill.number}/summaries?format=json`;
-          const summariesResponse = await fetchWithRetry(summariesUrl, `summaries ${billId}`);
-          if (summariesResponse && summariesResponse.ok) {
-            endpointBits |= SYNC_SUMMARIES;
-            const summariesData = await summariesResponse.json();
-            const summaries = summariesData.summaries || [];
-            for (const summary of summaries) {
-              await ctx.runMutation(internal.mutations.upsertBillSummary, {
-                billId,
-                actionDate: summary.actionDate,
-                actionDesc: summary.actionDesc,
-                text: summary.text || "",
-                updateDate: summary.updateDate || new Date().toISOString(),
-                versionCode: summary.versionCode,
-              });
-            }
-          }
-        } catch {
-          // Non-critical
-        }
-
-        // 5. Fetch and store text/PDF info (ALL versions, replace-all)
-        await delay(DELAY_BETWEEN_REQUESTS_MS);
-        try {
-          const textUrl = `${BASE_URL}/bill/${args.congress}/${args.billType}/${bill.number}/text?format=json`;
-          const textResponse = await fetchWithRetry(textUrl, `text ${billId}`);
-          if (textResponse && textResponse.ok) {
-            endpointBits |= SYNC_TEXT;
-            const textData = await textResponse.json();
-            await ctx.runMutation(internal.mutations.replaceBillTextVersions, {
-              billId,
-              versions: textVersionsToRows(textData.textVersions || []),
-            });
-            extraBits |= EXTRA_TEXT_VERSIONS;
-          }
-        } catch {
-          // Non-critical
-        }
-
-        // Track which endpoints succeeded for this bill
-        await ctx.runMutation(internal.mutations.updateBillSyncStatus, {
-          billId,
-          endpointBits,
-          lastSyncAttempt: new Date().toISOString(),
-        });
-
-        // Track enrichment progress separately (subjects + text versions).
-        if (extraBits > 0) {
-          await ctx.runMutation(internal.mutations.setBillExtraSyncedBits, {
-            billId,
-            bits: extraBits,
-          });
-        }
-
         successCount++;
       } catch (error: any) {
         console.error(`Error processing bill ${billId}: ${error.message}`);
@@ -581,6 +635,42 @@ export const syncBillBatch = internalAction({
     }
 
     return { processed: bills.length, hasMore, successCount, failCount };
+  },
+});
+
+/**
+ * Sync a single bill end-to-end — a thin wrapper around syncSingleBill for
+ * targeted remediation of an individual bill. Run from the CLI, e.g.
+ *   npx convex run congressApi:syncOneBill '{"congress":118,"billType":"hr","billNumber":"5193"}'
+ *
+ * Does NOT refresh the precomputed congressStats rollups (one bill rarely
+ * warrants a full-congress recompute); the bill aggregates update
+ * transactionally via the trigger-wrapped upsertBill. Run recomputeAllStats
+ * afterward if a rollup refresh is needed.
+ */
+export const syncOneBill = internalAction({
+  args: {
+    congress: v.number(),
+    billType: v.string(),
+    billNumber: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ billId: string; detailOk: boolean }> => {
+    const apiKey = process.env.CONGRESS_API_KEY;
+    if (!apiKey) throw new Error("CONGRESS_API_KEY not configured");
+
+    const { detailOk } = await syncSingleBill(
+      ctx,
+      args.congress,
+      args.billType,
+      args.billNumber,
+    );
+    return {
+      billId: `${args.billNumber}${args.billType}${args.congress}`,
+      detailOk,
+    };
   },
 });
 
@@ -723,6 +813,256 @@ export const initialHistoricalPull = internalAction({
         }
       );
     }
+  },
+});
+
+// ─── Completeness + freshness ────────────────────────────────────────────────
+const RECONCILE_LIST_PAGE = 250; // API list page size (max allowed)
+const RECONCILE_MAX_LIST_PAGES = 500; // 125k bills/type — far beyond any congress
+const RECONCILE_MAX_RUN_MS = 8 * 60 * 1000; // stop before the 10-min action kill
+const RECONCILE_TYPE_STAGGER_MS = 30 * 1000; // gap between bill types in a congress
+const RECONCILE_CONGRESS_STAGGER_MS = 20 * 60 * 1000; // gap between congresses
+
+/**
+ * Completeness reconciliation for one congress: for each bill type, paginate the
+ * FULL live API list (no fromDateTime), diff against the bill numbers already in
+ * the DB, and sync each genuinely-missing bill via syncSingleBill. Walks bill
+ * types one at a time via self-scheduling (billTypeIndex). On a rate-limit
+ * floor / circuit-breaker / time-budget stop it reschedules the SAME type — the
+ * re-diff skips bills inserted in the interrupted run, so it resumes cleanly.
+ * After the last type, refreshes the congress's precomputed rollups.
+ *
+ * Cheap in steady state (usually 0 missing). Recurs weekly across the current +
+ * 2 recent congresses via reconcileRecentCongresses, and is the one-time fix for
+ * never-synced closed-congress bills (e.g. 5193hr118):
+ *   npx convex run congressApi:reconcileMissingBills '{"congress":118}'
+ */
+export const reconcileMissingBills = internalAction({
+  args: {
+    congress: v.number(),
+    billTypeIndex: v.optional(v.number()),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    congress: number;
+    billType: string | null;
+    apiCount: number;
+    dbCount: number;
+    inserted: number;
+    done: boolean;
+    aborted: boolean;
+  }> => {
+    const apiKey = process.env.CONGRESS_API_KEY;
+    if (!apiKey) throw new Error("CONGRESS_API_KEY not configured");
+
+    const idx = args.billTypeIndex ?? 0;
+
+    // All bill types processed → run the end-of-congress recompute cascade.
+    if (idx >= BILL_TYPES.length) {
+      console.log(
+        `reconcileMissingBills: congress ${args.congress} complete; refreshing rollups`,
+      );
+      await ctx.runAction(internal.mutations.recomputeCongressStats, {
+        congress: args.congress,
+      });
+      await ctx.runAction(internal.mutations.recomputeCongressPolicyAreas, {
+        congress: args.congress,
+      });
+      await ctx.runAction(internal.mutations.recomputeCongressSponsors, {
+        congress: args.congress,
+      });
+      for (const chamber of ["house", "senate"] as const) {
+        await ctx.runAction(
+          internal.mutations.recomputeCongressChamberBreakdown,
+          { congress: args.congress, chamber },
+        );
+      }
+      return {
+        congress: args.congress,
+        billType: null,
+        apiCount: 0,
+        dbCount: 0,
+        inserted: 0,
+        done: true,
+        aborted: false,
+      };
+    }
+
+    const startedAt = Date.now();
+    const billType = BILL_TYPES[idx];
+
+    // 1. Collect the bill numbers already stored for this (congress, billType).
+    const dbSet = new Set<string>();
+    let cursor: string | null = null;
+    for (;;) {
+      const page: {
+        numbers: string[];
+        isDone: boolean;
+        continueCursor: string;
+      } = await ctx.runQuery(
+        internal.mutations.getBillNumbersForCongressType,
+        { congress: args.congress, billType, cursor, numItems: 2000 },
+      );
+      for (const n of page.numbers) dbSet.add(String(n));
+      if (page.isDone) break;
+      cursor = page.continueCursor;
+    }
+
+    // 2. Paginate the full live API list for this (congress, billType).
+    const apiNumbers: string[] = [];
+    let offset = 0;
+    for (let p = 0; p < RECONCILE_MAX_LIST_PAGES; p++) {
+      await delay(DELAY_BETWEEN_REQUESTS_MS);
+      const listUrl = `${BASE_URL}/bill/${args.congress}/${billType}?limit=${RECONCILE_LIST_PAGE}&offset=${offset}&format=json`;
+      const resp = await fetchWithRetry(
+        listUrl,
+        `reconcile list ${args.congress}/${billType} offset=${offset}`,
+      );
+      if (!resp || !resp.ok) break;
+      const data = await resp.json();
+      const bills = data.bills ?? [];
+      for (const b of bills) apiNumbers.push(String(b.number));
+      if (bills.length < RECONCILE_LIST_PAGE) break;
+      offset += RECONCILE_LIST_PAGE;
+    }
+
+    const missing = apiNumbers.filter((n) => !dbSet.has(n));
+    console.log(
+      `reconcileMissingBills ${args.congress}/${billType}: api=${apiNumbers.length} db=${dbSet.size} missing=${missing.length}`,
+    );
+
+    // 3. Sync each missing bill, with the same protections as the batch sync.
+    let inserted = 0;
+    let consecutiveFailures = 0;
+    let aborted = false;
+    for (const number of missing) {
+      if (consecutiveFailures >= CONSECUTIVE_FAIL_LIMIT) {
+        console.error(
+          `reconcileMissingBills: circuit breaker for ${args.congress}/${billType}; will resume this type`,
+        );
+        aborted = true;
+        break;
+      }
+      if (
+        lastRateLimitRemaining !== null &&
+        lastRateLimitRemaining < SYNC_RATE_FLOOR
+      ) {
+        console.warn(
+          `reconcileMissingBills: rate floor hit (${lastRateLimitRemaining}); deferring ${args.congress}/${billType}`,
+        );
+        aborted = true;
+        break;
+      }
+      if (Date.now() - startedAt > RECONCILE_MAX_RUN_MS) {
+        console.log(
+          `reconcileMissingBills: time budget reached on ${args.congress}/${billType}; resuming this type`,
+        );
+        aborted = true;
+        break;
+      }
+      try {
+        const { detailOk } = await syncSingleBill(
+          ctx,
+          args.congress,
+          billType,
+          number,
+        );
+        if (detailOk) {
+          inserted++;
+          consecutiveFailures = 0;
+        } else {
+          consecutiveFailures++;
+        }
+      } catch (err: any) {
+        console.error(
+          `reconcileMissingBills: failed ${number}${billType}${args.congress}: ${err?.message ?? err}`,
+        );
+        consecutiveFailures++;
+      }
+    }
+
+    // Resume the SAME type (re-diff skips inserted bills) on an interrupted run;
+    // otherwise advance to the next type.
+    if (aborted) {
+      await ctx.scheduler.runAfter(
+        RATE_LIMIT_RESUME_DELAY_MS,
+        internal.congressApi.reconcileMissingBills,
+        { congress: args.congress, billTypeIndex: idx },
+      );
+    } else {
+      await ctx.scheduler.runAfter(
+        RECONCILE_TYPE_STAGGER_MS,
+        internal.congressApi.reconcileMissingBills,
+        { congress: args.congress, billTypeIndex: idx + 1 },
+      );
+    }
+
+    return {
+      congress: args.congress,
+      billType,
+      apiCount: apiNumbers.length,
+      dbCount: dbSet.size,
+      inserted,
+      done: false,
+      aborted,
+    };
+  },
+});
+
+/**
+ * Weekly completeness sweep: reconcile missing bills for the current + 2 most
+ * recent congresses, staggered so they never overlap. Closed congresses are
+ * effectively final, so finding anything here is rare — this is the safety net
+ * for never-synced bills the bounded daily/weekly lookback windows can't
+ * discover (the daily/weekly sync only sees bills updated in the last 26h/7d,
+ * and only for the current congress).
+ */
+export const reconcileRecentCongresses = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const currentYear = new Date().getFullYear();
+    const currentCongress = Math.floor((currentYear - 1789) / 2) + 1;
+    const congresses = [
+      currentCongress,
+      currentCongress - 1,
+      currentCongress - 2,
+    ];
+    for (let i = 0; i < congresses.length; i++) {
+      await ctx.scheduler.runAfter(
+        i * RECONCILE_CONGRESS_STAGGER_MS,
+        internal.congressApi.reconcileMissingBills,
+        { congress: congresses[i], billTypeIndex: 0 },
+      );
+    }
+    console.log(
+      `reconcileRecentCongresses: scheduled reconciliation for ${congresses.join(", ")}`,
+    );
+  },
+});
+
+/**
+ * Monthly full re-pull of the current congress: re-fetch every bill (no
+ * fromDateTime) so stage + latestActionDate are re-derived, enrichment is
+ * refreshed, missing bills are inserted, and present-but-stale bills (e.g. a
+ * bill the live API has since advanced to "Became Law") are corrected. The most
+ * reliable freshness mechanism for the only congress whose data still changes.
+ */
+export const monthlyCurrentCongressRepull = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const currentYear = new Date().getFullYear();
+    const currentCongress = Math.floor((currentYear - 1789) / 2) + 1;
+    console.log(
+      `monthlyCurrentCongressRepull: full re-pull of Congress ${currentCongress}`,
+    );
+    await ctx.scheduler.runAfter(0, internal.congressApi.syncCongress, {
+      congress: currentCongress,
+      syncType: "monthly",
+      // No fromDateTime → full re-fetch of every bill type.
+      staggerMs: FULL_SYNC_STAGGER_MS,
+    });
   },
 });
 
@@ -1019,15 +1359,18 @@ const STAGE_BACKFILL_PAGE = 40; // bills per mutation (≤250 actions each → r
 const STAGE_BACKFILL_BILLS_PER_RUN = 5000; // bills per invocation before self-scheduling
 
 /**
- * Re-derive the progress stage for ALL existing bills from their stored
- * actions, using the corrected calculator (no API calls). Patches only bills
- * whose stage changed; the trigger-wrapped mutation keeps the aggregates in
- * sync. Self-schedules across batches and, on completion, refreshes the
- * precomputed homepage stats (Part 1c). Idempotent and safe to re-run.
+ * Re-derive ALL existing bills' action-derived fields from their stored actions
+ * (no API calls): the corrected progress stage AND latestActionDate (max stored
+ * actionDate). Patches only bills whose values changed; the trigger-wrapped
+ * mutation keeps the aggregates in sync. Self-schedules across batches and, on
+ * completion, refreshes the precomputed homepage stats. Idempotent and safe to
+ * re-run.
  *
- * Run from the CLI: `npx convex run congressApi:backfillBillStages '{}'`.
+ * This is the no-API fix for the ~90% of bills missing latestActionDate (which
+ * silently excluded them from the /bills "last action date" recency filter):
+ *   npx convex run congressApi:backfillBillFieldsFromActions '{}'
  */
-export const backfillBillStages = internalAction({
+export const backfillBillFieldsFromActions = internalAction({
   args: { cursor: v.optional(v.union(v.string(), v.null())) },
   handler: async (
     ctx,
@@ -1045,13 +1388,14 @@ export const backfillBillStages = internalAction({
 
       if (page.bills.length > 0) {
         const { changed } = await ctx.runMutation(
-          internal.mutations.rederiveStagesForBills,
+          internal.mutations.rederiveBillFieldsFromActions,
           {
             bills: page.bills.map((b) => ({
               _id: b._id,
               billId: b.billId,
               progressStage: b.progressStage,
               progressDescription: b.progressDescription,
+              latestActionDate: b.latestActionDate,
             })),
           },
         );
@@ -1061,9 +1405,9 @@ export const backfillBillStages = internalAction({
 
       if (page.isDone) {
         console.log(
-          `backfillBillStages: pass complete, ${changedThisRun} stages changed this run; refreshing rollups`,
+          `backfillBillFieldsFromActions: pass complete, ${changedThisRun} bills changed this run; refreshing rollups`,
         );
-        // Part 1c: refresh precomputed homepage stats so corrected stages show.
+        // Refresh precomputed homepage stats so corrected stages show.
         await ctx.scheduler.runAfter(0, internal.congressApi.recomputeAllStats, {});
         return { done: true, processedThisRun, changedThisRun };
       }
@@ -1073,11 +1417,11 @@ export const backfillBillStages = internalAction({
       if (processedThisRun >= STAGE_BACKFILL_BILLS_PER_RUN) {
         await ctx.scheduler.runAfter(
           1000,
-          internal.congressApi.backfillBillStages,
+          internal.congressApi.backfillBillFieldsFromActions,
           { cursor },
         );
         console.log(
-          `backfillBillStages: processed ${processedThisRun} (changed ${changedThisRun}); scheduled continuation`,
+          `backfillBillFieldsFromActions: processed ${processedThisRun} (changed ${changedThisRun}); scheduled continuation`,
         );
         return { done: false, processedThisRun, changedThisRun };
       }
@@ -1339,9 +1683,14 @@ export const backfillEnrichmentStatus = internalAction({
 export const recomputeAllStats = internalAction({
   args: {},
   handler: async (ctx): Promise<{ congresses: number[] }> => {
-    // Find which congresses exist by probing the index
+    // Find which congresses exist by probing the index. The upper bound tracks
+    // the current congress (never below 120, the last hardcoded value) so a
+    // newly-seated congress is never silently dropped from the rollups.
+    const currentCongress =
+      Math.floor((new Date().getFullYear() - 1789) / 2) + 1;
+    const upperCongress = Math.max(120, currentCongress);
     const congressesToUpdate: number[] = [];
-    for (let c = 93; c <= 120; c++) {
+    for (let c = 93; c <= upperCongress; c++) {
       const bills = await ctx.runQuery(internal.bills.hasBillsForCongress, { congress: c });
       if (bills) congressesToUpdate.push(c);
     }
@@ -1396,8 +1745,13 @@ export const triggerRecomputeStats = internalAction({
 export const recomputeAllSponsors = internalAction({
   args: {},
   handler: async (ctx): Promise<{ congresses: number[] }> => {
+    // Upper bound tracks the current congress (never below 120) so a
+    // newly-seated congress self-populates without a code change.
+    const currentCongress =
+      Math.floor((new Date().getFullYear() - 1789) / 2) + 1;
+    const upperCongress = Math.max(120, currentCongress);
     const congressesToUpdate: number[] = [];
-    for (let c = 93; c <= 120; c++) {
+    for (let c = 93; c <= upperCongress; c++) {
       const hasBills = await ctx.runQuery(internal.bills.hasBillsForCongress, {
         congress: c,
       });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -33,4 +33,25 @@ crons.daily(
   {},
 );
 
+// Run monthly on the 1st at 5:00 AM UTC - full re-pull of the current congress.
+// The most reliable freshness mechanism: re-derives stage + latestActionDate,
+// refreshes enrichment, inserts missing bills, and corrects present-but-stale
+// bills (closed congresses are final, so only the current one needs this).
+crons.cron(
+  "monthly-current-congress-repull",
+  "0 5 1 * *",
+  internal.congressApi.monthlyCurrentCongressRepull,
+  {},
+);
+
+// Run weekly on Monday at 6:00 AM UTC - completeness reconciliation across the
+// current + 2 most recent congresses. Inserts never-synced bills the bounded
+// daily/weekly lookback windows can't discover.
+crons.cron(
+  "weekly-reconcile-recent-congresses",
+  "0 6 * * 1",
+  internal.congressApi.reconcileRecentCongresses,
+  {},
+);
+
 export default crons;

--- a/convex/llm.ts
+++ b/convex/llm.ts
@@ -3,6 +3,7 @@ import { internal, api } from "./_generated/api";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { rateLimiter } from "./rateLimits";
+import { BillStageDescriptions as STAGE_DESCRIPTIONS } from "./billStage";
 
 const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const MODEL = "groq/compound-mini";
@@ -28,17 +29,6 @@ interface BillContext {
   pdfUrl: string;
   actions: Array<{ date: string; description: string }>;
 }
-
-const STAGE_DESCRIPTIONS: Record<number, string> = {
-  20: "Introduced",
-  40: "In Committee",
-  60: "Passed One Chamber",
-  80: "Passed Both Chambers",
-  85: "Vetoed",
-  90: "To President",
-  95: "Signed by President",
-  100: "Became Law",
-};
 
 const PARTY_NAMES: Record<string, string> = {
   R: "Republican",

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -10,6 +10,7 @@ import {
   HOUSE_BILL_TYPES,
   SENATE_BILL_TYPES,
 } from "./aggregates";
+import { calculateBillStage } from "./billStage";
 
 /**
  * Upsert a bill record. If a bill with the same billId exists, update it.
@@ -224,6 +225,96 @@ export const upsertBillTitles = internalMutation({
 });
 
 /**
+ * Replace ALL detailed legislative subjects for a bill (one-to-many). Distinct
+ * from upsertBillSubject, which stores the single policy area. Called by the
+ * sync and the enrichment backfill after paginating the /subjects endpoint.
+ */
+export const replaceBillLegislativeSubjects = internalMutation({
+  args: {
+    billId: v.string(),
+    subjects: v.array(
+      v.object({
+        name: v.string(),
+        updateDate: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("billLegislativeSubjects")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .collect();
+    for (const doc of existing) {
+      await ctx.db.delete(doc._id);
+    }
+    for (const subject of args.subjects) {
+      await ctx.db.insert("billLegislativeSubjects", {
+        billId: args.billId,
+        name: subject.name,
+        updateDate: subject.updateDate,
+      });
+    }
+  },
+});
+
+/**
+ * Replace ALL text versions for a bill (one-to-many). The sync used to keep
+ * only the single last array element; this stores every version so the
+ * current-text selection in `getById` can pick by finality/date.
+ */
+export const replaceBillTextVersions = internalMutation({
+  args: {
+    billId: v.string(),
+    versions: v.array(
+      v.object({
+        date: v.optional(v.string()),
+        formatsUrlTxt: v.optional(v.string()),
+        formatsUrlPdf: v.optional(v.string()),
+        type: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("billText")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .collect();
+    for (const doc of existing) {
+      await ctx.db.delete(doc._id);
+    }
+    for (const version of args.versions) {
+      await ctx.db.insert("billText", {
+        billId: args.billId,
+        ...version,
+      });
+    }
+  },
+});
+
+/**
+ * OR-in enrichment progress bits on a bill (1 = legislativeSubjects stored,
+ * 2 = all text versions stored). Kept separate from `syncedEndpoints` so the
+ * existing repair / SYNC_COMPLETE logic is untouched.
+ */
+export const setBillExtraSyncedBits = internalMutation({
+  args: {
+    billId: v.string(),
+    bits: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("bills")
+      .withIndex("by_billId", (q) => q.eq("billId", args.billId))
+      .first();
+    if (!existing) return;
+    const current = existing.extraSyncedBits || 0;
+    await ctx.db.patch(existing._id, {
+      extraSyncedBits: current | args.bits,
+    });
+  },
+});
+
+/**
  * Update the sync status bitmask for a bill.
  * Uses bitwise OR so bits are only ever added, never removed.
  */
@@ -377,6 +468,93 @@ export const getBillsPageByCongress = internalQuery({
       .query("bills")
       .withIndex("by_congress", (q) => q.eq("congress", args.congress))
       .paginate({ cursor: args.cursor, numItems: args.numItems });
+  },
+});
+
+/**
+ * Paginated fetch of the whole bills table, returning just the fields the
+ * backfills / status checks need. Shared by `backfillBillStages` (stage
+ * re-derivation), `backfillBillEnrichment` (subjects + text), and
+ * `backfillEnrichmentStatus` (progress counts).
+ */
+export const getBillBackfillPage = internalQuery({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("bills")
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+    return {
+      bills: page.page.map((b) => ({
+        _id: b._id,
+        billId: b.billId,
+        congress: b.congress,
+        billType: b.billType,
+        billNumber: b.billNumber,
+        progressStage: b.progressStage,
+        progressDescription: b.progressDescription,
+        extraSyncedBits: b.extraSyncedBits ?? 0,
+      })),
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+    };
+  },
+});
+
+/**
+ * Re-derive the progress stage for a batch of bills from their stored actions
+ * (no API calls) and patch only those whose stage actually changed. Uses the
+ * trigger-wrapped internalMutation so the billsByStage / billsByChamber
+ * aggregates stay in sync automatically. Bills with no stored actions are
+ * skipped (we can't derive a stage without them).
+ *
+ * numItems at the call site is kept small (≤40) so reading up to 250 actions
+ * per bill stays within Convex's per-transaction read limit.
+ */
+export const rederiveStagesForBills = internalMutation({
+  args: {
+    bills: v.array(
+      v.object({
+        _id: v.id("bills"),
+        billId: v.string(),
+        progressStage: v.optional(v.number()),
+        progressDescription: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    let changed = 0;
+    let skippedNoActions = 0;
+    for (const bill of args.bills) {
+      const actions = await ctx.db
+        .query("billActions")
+        .withIndex("by_billId", (q) => q.eq("billId", bill.billId))
+        .take(250);
+      if (actions.length === 0) {
+        skippedNoActions++;
+        continue;
+      }
+      const { stage, description } = calculateBillStage(
+        actions.map((a) => ({
+          text: a.text,
+          type: a.type,
+          actionCode: a.actionCode,
+        })),
+      );
+      if (
+        bill.progressStage !== stage ||
+        bill.progressDescription !== description
+      ) {
+        await ctx.db.patch(bill._id, {
+          progressStage: stage,
+          progressDescription: description,
+        });
+        changed++;
+      }
+    }
+    return { changed, skippedNoActions };
   },
 });
 

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -473,9 +473,9 @@ export const getBillsPageByCongress = internalQuery({
 
 /**
  * Paginated fetch of the whole bills table, returning just the fields the
- * backfills / status checks need. Shared by `backfillBillStages` (stage
- * re-derivation), `backfillBillEnrichment` (subjects + text), and
- * `backfillEnrichmentStatus` (progress counts).
+ * backfills / status checks need. Shared by `backfillBillFieldsFromActions`
+ * (stage + latestActionDate re-derivation), `backfillBillEnrichment` (subjects
+ * + text), and `backfillEnrichmentStatus` (progress counts).
  */
 export const getBillBackfillPage = internalQuery({
   args: {
@@ -495,6 +495,7 @@ export const getBillBackfillPage = internalQuery({
         billNumber: b.billNumber,
         progressStage: b.progressStage,
         progressDescription: b.progressDescription,
+        latestActionDate: b.latestActionDate,
         extraSyncedBits: b.extraSyncedBits ?? 0,
       })),
       isDone: page.isDone,
@@ -504,16 +505,22 @@ export const getBillBackfillPage = internalQuery({
 });
 
 /**
- * Re-derive the progress stage for a batch of bills from their stored actions
- * (no API calls) and patch only those whose stage actually changed. Uses the
- * trigger-wrapped internalMutation so the billsByStage / billsByChamber
+ * Re-derive a batch of bills' action-derived fields from their stored actions
+ * (no API calls) and patch only those that actually changed:
+ *   - progressStage / progressDescription (corrected stage calculator), and
+ *   - latestActionDate (max stored actionDate — same reducer as
+ *     upsertBillActions, so a backfilled value is identical to what a fresh
+ *     sync would store).
+ *
+ * Uses the trigger-wrapped internalMutation so the billsByStage / billsByChamber
  * aggregates stay in sync automatically. Bills with no stored actions are
- * skipped (we can't derive a stage without them).
+ * skipped — correctly leaving latestActionDate unset, which is the intended
+ * "excluded from recency filters" state.
  *
  * numItems at the call site is kept small (≤40) so reading up to 250 actions
  * per bill stays within Convex's per-transaction read limit.
  */
-export const rederiveStagesForBills = internalMutation({
+export const rederiveBillFieldsFromActions = internalMutation({
   args: {
     bills: v.array(
       v.object({
@@ -521,6 +528,7 @@ export const rederiveStagesForBills = internalMutation({
         billId: v.string(),
         progressStage: v.optional(v.number()),
         progressDescription: v.optional(v.string()),
+        latestActionDate: v.optional(v.string()),
       }),
     ),
   },
@@ -543,18 +551,63 @@ export const rederiveStagesForBills = internalMutation({
           actionCode: a.actionCode,
         })),
       );
+      // Mirror upsertBillActions' max-actionDate reducer exactly.
+      const latestActionDate =
+        actions.reduce<string | null>(
+          (latest, a) =>
+            latest === null || a.actionDate > latest ? a.actionDate : latest,
+          null,
+        ) ?? undefined;
+
+      const patch: {
+        progressStage?: number;
+        progressDescription?: string;
+        latestActionDate?: string;
+      } = {};
       if (
         bill.progressStage !== stage ||
         bill.progressDescription !== description
       ) {
-        await ctx.db.patch(bill._id, {
-          progressStage: stage,
-          progressDescription: description,
-        });
+        patch.progressStage = stage;
+        patch.progressDescription = description;
+      }
+      if (latestActionDate && bill.latestActionDate !== latestActionDate) {
+        patch.latestActionDate = latestActionDate;
+      }
+      if (Object.keys(patch).length > 0) {
+        await ctx.db.patch(bill._id, patch);
         changed++;
       }
     }
     return { changed, skippedNoActions };
+  },
+});
+
+/**
+ * Paginated fetch of the stored bill numbers for one (congress, billType).
+ * Used by reconcileMissingBills to diff the DB against the live API list.
+ * Lives here (a permanent module) rather than in the temporary audit module so
+ * the recurring reconciliation cron has no dependency on audit.ts's lifecycle.
+ */
+export const getBillNumbersForCongressType = internalQuery({
+  args: {
+    congress: v.number(),
+    billType: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("bills")
+      .withIndex("by_congress_and_type", (q) =>
+        q.eq("congress", args.congress).eq("billType", args.billType),
+      )
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+    return {
+      numbers: page.page.map((b) => b.billNumber),
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+    };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -91,6 +91,10 @@ export default defineSchema({
     progressDescription: v.optional(v.string()),
     latestActionDate: v.optional(v.string()),
     syncedEndpoints: v.optional(v.number()), // bitmask: 1=detail, 2=actions, 4=subjects, 8=summaries, 16=text
+    // Enrichment progress, kept SEPARATE from syncedEndpoints so the existing
+    // repair logic / SYNC_COMPLETE checks are untouched. Bits:
+    //   1 = all legislativeSubjects stored, 2 = all text versions stored.
+    extraSyncedBits: v.optional(v.number()),
     lastSyncAttempt: v.optional(v.string()), // ISO timestamp of last sync attempt
     updatedAt: v.string(),
   })
@@ -146,6 +150,19 @@ export default defineSchema({
     formatsUrlPdf: v.optional(v.string()),
     type: v.optional(v.string()),
   }).index("by_billId", ["billId"]),
+
+  // Detailed legislative subjects (one-to-many: bill -> subjects). Distinct
+  // from the single policy area kept in billSubjects — the Library of Congress
+  // returns a rich list of legislative subjects per bill (e.g. HR1/119 has
+  // 239). Stored replace-all per bill by the sync + enrichment backfill, and
+  // indexed by name to support a future "filter by subject" feature.
+  billLegislativeSubjects: defineTable({
+    billId: v.string(),
+    name: v.string(),
+    updateDate: v.optional(v.string()),
+  })
+    .index("by_billId", ["billId"])
+    .index("by_name", ["name"]),
 
   // Bill title variations (one-to-many: bill -> titles)
   billTitles: defineTable({

--- a/convex/sync.ts
+++ b/convex/sync.ts
@@ -9,6 +9,13 @@ export const SYNC_SUMMARIES = 8; // bit 3
 export const SYNC_TEXT = 16; // bit 4
 export const SYNC_COMPLETE = 31; // all bits set
 
+// Enrichment bitmask (bills.extraSyncedBits) — kept SEPARATE from the endpoint
+// bitmask above so the repair / SYNC_COMPLETE flow is untouched. Tracks the
+// richer data that the original sync fetched but discarded.
+export const EXTRA_LEGISLATIVE_SUBJECTS = 1; // bit 0: all legislativeSubjects stored
+export const EXTRA_TEXT_VERSIONS = 2; // bit 1: all text versions stored
+export const EXTRA_COMPLETE = 3; // all enrichment bits set
+
 const ENDPOINT_NAMES: Record<number, string> = {
   [SYNC_DETAIL]: "detail",
   [SYNC_ACTIONS]: "actions",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "generate-icons": "tsx scripts/generate-icons.ts",
     "optimize-images": "tsx scripts/optimize-images.ts",
+    "test": "tsx convex/billStage.test.ts",
     "cf:build": "npm run generate-icons && opennextjs-cloudflare build",
     "preview": "npm run cf:build && opennextjs-cloudflare preview",
     "deploy": "npm run cf:build && opennextjs-cloudflare deploy",


### PR DESCRIPTION
## Summary

Root-cause fixes for three pre-existing bill-data gaps that all stem from the Convex sync pipeline. Backend-only; no website republish and no new user-facing events (so no `ANALYTICS.md` change).

1. **`latestActionDate` missing on ~90% of bills** silently excluded them from the `/bills` "last action date" recency filter. Backfilled (no API) from stored actions, derived in the same pass as the stage re-derivation. Every future sync already sets it.
2. **Never-synced bills** the live API has but we don't (the sync only discovers *recently-updated* bills in the *current* congress). New `reconcileMissingBills` diffs the full API list against the DB per `(congress, billType)` and inserts what's missing.
3. **Present-but-stale bills.** New `monthlyCurrentCongressRepull` does a full no-window re-pull of the current congress — re-derives stage + `latestActionDate`, refreshes enrichment, inserts missing, and corrects stale-present bills.

## Supporting changes
- Extracted `syncSingleBill` from `syncBillBatch` (behavior-preserving) + thin `syncOneBill` wrapper for targeted single-bill remediation.
- Proactive rate-limit floor in `syncBillBatch` so a heavy re-pull backs off before starving the daily incremental sync.
- Two new crons: monthly current-congress re-pull; weekly reconciliation across current + 2 recent congresses.
- `recomputeAllStats` / `recomputeAllSponsors` congress bounds are now `currentCongress`-relative (never below 120) so a newly-seated congress isn't dropped.
- Shared bill-numbers query kept in `mutations.ts` (permanent) so the recurring reconciliation never depends on the temporary `audit.ts`.
- Committed the read-only `audit.ts` diagnostics module (writes nothing) used by the verification step.

## Verification
- `npx convex codegen` (typecheck) — clean
- `npm test` (stage calculator) — 13/13 pass
- `npm run build` — succeeds

## Not in this PR (gated, production ops)
- `npx convex deploy` and the API-touching one-time remediation (insert never-synced bills, full re-pull of 119) are **gated on the in-flight enrichment backfill finishing** (currently ~7% done) to avoid contending for the data-provider request budget. The no-API `latestActionDate` backfill can run as soon as this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
