### PR TITLE
Add saved bills: bookmark from bill pages, list on account page

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -100,6 +100,8 @@ page is interactive (civics guide) and fires its own custom events — see "Lear
 |---|---|---|---|
 | `bill_viewed` | Bill detail page rendered (top of the chat funnel) | `bill_id`, `bill_type`, `bill_number`, `congress`, `policy_area`, `progress_stage`, `has_summary`, `has_pdf` | `components/bills/bill-details.tsx` |
 | `bill_pdf_opened` | User clicks "Read full text (PDF)" | `bill_id` | `components/bills/bill-details.tsx` |
+| `bill_save_toggled` | Signed-in user saves or unsaves a bill on the detail page | `bill_id`, `action: "saved" \| "unsaved"`, `bill_type`, `bill_number`, `congress`, `policy_area`, `progress_stage` | `components/bills/save-bill-button.tsx` |
+| `bill_save_signin_redirected` | Signed-out user clicked Save and was sent to sign-in (conversion moment) | `bill_id` | `components/bills/save-bill-button.tsx` |
 | `bill_chat_question_submitted` | User submits a question to bill chat | `bill_id`, `question`, `question_length`, `source: "typed" \| "example"`, `question_number`, `user_type: "anonymous" \| "authed"` | `components/bills/bill-qa.tsx` |
 | `bill_chat_answer_received` | AI answer came back successfully | `bill_id`, `response_ms`, `answer_length` | `components/bills/bill-qa.tsx` |
 | `bill_chat_failed` | Chat request errored (not rate limit) | `bill_id`, `error` | `components/bills/bill-qa.tsx` |

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -27,6 +27,7 @@ export default function AccountPage() {
 
 function AccountInner() {
   const user = useQuery(api.users.currentUser, {});
+  const savedBills = useQuery(api.savedBills.listSaved, {});
   const { signOut } = useAuthActions();
   const [chatUsage, setChatUsage] = React.useState<ChatUsageResult | null>(null);
 
@@ -164,6 +165,66 @@ function AccountInner() {
           </CardContent>
         </Card>
       </div>
+
+      <section className="space-y-4">
+        <h2 className="font-serif text-xl font-semibold tracking-tight">Saved bills</h2>
+        {savedBills === undefined ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : savedBills.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No saved bills yet.{" "}
+            <Link href="/bills" className="underline underline-offset-4">
+              Browse bills
+            </Link>{" "}
+            and tap Save on any bill to keep it here.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border border-y border-border">
+            {savedBills.map((row) =>
+              row.bill ? (
+                <li key={row.billId}>
+                  <Link
+                    href={`/bills/${row.billId}`}
+                    className="group flex items-baseline justify-between gap-4 py-4"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                        {row.bill.billTypeLabel} {row.bill.billNumber} · {row.bill.congress}th
+                        Congress
+                      </p>
+                      <p className="mt-1 font-serif font-medium leading-snug group-hover:underline underline-offset-4">
+                        {row.bill.title}
+                      </p>
+                      {row.bill.progressDescription && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {row.bill.progressDescription}
+                        </p>
+                      )}
+                    </div>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      Saved{" "}
+                      {new Intl.DateTimeFormat("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      }).format(new Date(row.savedAt))}
+                    </span>
+                  </Link>
+                </li>
+              ) : (
+                <li
+                  key={row.billId}
+                  className="flex items-baseline justify-between gap-4 py-4"
+                >
+                  <p className="text-sm text-muted-foreground">
+                    This bill is no longer available{" "}
+                    <span className="font-mono text-xs">({row.billId})</span>
+                  </p>
+                </li>
+              ),
+            )}
+          </ul>
+        )}
+      </section>
 
       <div className="border-t border-border pt-6">
         <Button

--- a/components/bills/bill-details.tsx
+++ b/components/bills/bill-details.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/utils/bill-stages';
 import { analytics } from '@/lib/analytics';
 import BillQA from './bill-qa';
+import SaveBillButton from './save-bill-button';
 import PodcastPromo from '@/components/podcast-promo';
 import { ArrowLeft, FileText, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -165,6 +166,16 @@ export default function BillDetails({ bill }: BillDetailsProps) {
                   </a>
                 </>
               )}
+              <SaveBillButton
+                billId={String(bill.id)}
+                analyticsProps={{
+                  bill_type: bill.bill_type,
+                  bill_number: bill.bill_number,
+                  congress: bill.congress,
+                  policy_area: bill.bill_subjects?.policy_area_name ?? '',
+                  progress_stage: progressStage,
+                }}
+              />
             </div>
           </div>
         </div>

--- a/components/bills/save-bill-button.tsx
+++ b/components/bills/save-bill-button.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useConvexAuth, useMutation, useQuery } from 'convex/react';
+import { ConvexError } from 'convex/values';
+import { Bookmark } from 'lucide-react';
+
+import { api } from '@/convex/_generated/api';
+import { analytics } from '@/lib/analytics';
+import { useConvexEnabled } from '@/app/ConvexClientProvider';
+
+interface SaveBillButtonProps {
+  billId: string;
+  analyticsProps: {
+    bill_type: string;
+    bill_number: string;
+    congress: number;
+    policy_area: string;
+    progress_stage: number | string;
+  };
+}
+
+/**
+ * Save/Saved bookmark toggle for the bill detail header. Self-contained so
+ * bill-details.tsx stays free of Convex hooks. Renders nothing (including its
+ * leading separator) when Convex isn't configured.
+ */
+export default function SaveBillButton(props: SaveBillButtonProps) {
+  const enabled = useConvexEnabled();
+  if (!enabled) return null;
+  return <SaveBillButtonInner {...props} />;
+}
+
+function SaveBillButtonInner({ billId, analyticsProps }: SaveBillButtonProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isAuthenticated } = useConvexAuth();
+  const [pending, setPending] = useState(false);
+
+  const isSaved = useQuery(api.savedBills.isSaved, { billId });
+  const toggleSave = useMutation(api.savedBills.toggleSave).withOptimisticUpdate(
+    (store, args) => {
+      const current = store.getQuery(api.savedBills.isSaved, { billId: args.billId });
+      if (current !== undefined) {
+        store.setQuery(api.savedBills.isSaved, { billId: args.billId }, !current);
+      }
+    },
+  );
+
+  const redirectToSignIn = () => {
+    router.push(`/sign-in?redirect=${encodeURIComponent(pathname ?? '/bills')}`);
+  };
+
+  const handleClick = async () => {
+    if (!isAuthenticated) {
+      analytics.billSaveSigninRedirected(billId);
+      redirectToSignIn();
+      return;
+    }
+    // One toggle (and one analytics event) at a time — rapid clicks would
+    // otherwise double-count bill_save_toggled.
+    if (pending) return;
+    setPending(true);
+    try {
+      const { saved } = await toggleSave({ billId });
+      analytics.billSaveToggled({
+        bill_id: billId,
+        action: saved ? 'saved' : 'unsaved',
+        ...analyticsProps,
+      });
+    } catch (error) {
+      // Signed out mid-session — the token expired between render and click.
+      if (error instanceof ConvexError && error.data === 'UNAUTHENTICATED') {
+        redirectToSignIn();
+        return;
+      }
+      console.warn('Failed to toggle saved bill:', error);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <>
+      <span className="hidden sm:inline">·</span>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isSaved === undefined}
+        aria-pressed={isSaved === true}
+        className="inline-flex items-center gap-1.5 text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground disabled:opacity-50"
+      >
+        <Bookmark
+          className="h-3.5 w-3.5"
+          fill={isSaved ? 'currentColor' : 'none'}
+        />
+        {isSaved ? 'Saved' : 'Save'}
+      </button>
+    </>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as http from "../http.js";
 import type * as llm from "../llm.js";
 import type * as mutations from "../mutations.js";
 import type * as rateLimits from "../rateLimits.js";
+import type * as savedBills from "../savedBills.js";
 import type * as sync from "../sync.js";
 import type * as users from "../users.js";
 
@@ -50,6 +51,7 @@ declare const fullApi: ApiFromModules<{
   llm: typeof llm;
   mutations: typeof mutations;
   rateLimits: typeof rateLimits;
+  savedBills: typeof savedBills;
   sync: typeof sync;
   users: typeof users;
 }>;

--- a/convex/savedBills.ts
+++ b/convex/savedBills.ts
@@ -1,0 +1,107 @@
+import { v, ConvexError } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { query, mutation } from "./_generated/server";
+import { requireUser } from "./users";
+
+// Account-page list cap. Bookmarks are added one click at a time, so 200 is
+// far beyond realistic use; rows past it still exist, they just fall off the
+// list view. Keeps the query bounded without pagination UI.
+const MAX_SAVED_BILLS = 200;
+
+/**
+ * Whether the current user has saved the given bill. Anonymous callers get
+ * `false` (never throws — the save button renders for signed-out visitors).
+ */
+export const isSaved = query({
+  args: { billId: v.string() },
+  handler: async (ctx, { billId }) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return false;
+    const existing = await ctx.db
+      .query("savedBills")
+      .withIndex("by_user_and_bill", (q) =>
+        q.eq("userId", userId).eq("billId", billId),
+      )
+      .unique();
+    return existing !== null;
+  },
+});
+
+/**
+ * Toggle a bookmark for the current user. Returns the resulting state so the
+ * client can report accurate analytics.
+ */
+export const toggleSave = mutation({
+  args: { billId: v.string() },
+  handler: async (ctx, { billId }) => {
+    const user = await requireUser(ctx);
+
+    const existing = await ctx.db
+      .query("savedBills")
+      .withIndex("by_user_and_bill", (q) =>
+        q.eq("userId", user._id).eq("billId", billId),
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.delete(existing._id);
+      return { saved: false };
+    }
+
+    // Reject saves of bills that don't exist (forged/stale client calls).
+    const bill = await ctx.db
+      .query("bills")
+      .withIndex("by_billId", (q) => q.eq("billId", billId))
+      .first();
+    if (!bill) throw new ConvexError("BILL_NOT_FOUND");
+
+    await ctx.db.insert("savedBills", {
+      userId: user._id,
+      billId,
+      savedAt: Date.now(),
+    });
+    return { saved: true };
+  },
+});
+
+/**
+ * The current user's saved bills, newest first, joined with display fields
+ * from the bills table. Missing bills come back as `bill: null` so the UI can
+ * still show (and explain) the row. Anonymous callers get an empty list —
+ * /account is middleware-gated, but a query desync must not throw.
+ */
+export const listSaved = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return [];
+
+    const rows = await ctx.db
+      .query("savedBills")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .order("desc")
+      .take(MAX_SAVED_BILLS);
+
+    return await Promise.all(
+      rows.map(async (row) => {
+        const bill = await ctx.db
+          .query("bills")
+          .withIndex("by_billId", (q) => q.eq("billId", row.billId))
+          .first();
+        return {
+          billId: row.billId,
+          savedAt: row.savedAt,
+          bill: bill
+            ? {
+                title: bill.title,
+                billTypeLabel: bill.billTypeLabel,
+                billNumber: bill.billNumber,
+                congress: bill.congress,
+                progressDescription: bill.progressDescription ?? null,
+              }
+            : null,
+        };
+      }),
+    );
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -72,6 +72,16 @@ export default defineSchema({
     .index("by_user_and_kind", ["userId", "kind"])
     .index("by_user_and_createdAt", ["userId", "createdAt"]),
 
+  // Saved bills (plain bookmarks). One row per (user, bill); unsave deletes
+  // the row, so a re-save gets a fresh _creationTime and sorts as newest.
+  savedBills: defineTable({
+    userId: v.id("users"),
+    billId: v.string(), // References bills.billId composite key, e.g. "1hr119"
+    savedAt: v.number(), // epoch ms
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_and_bill", ["userId", "billId"]),
+
   // ─── Bills domain ──────────────────────────────────────────────────────────
   // Main bill info table
   bills: defineTable({

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -179,6 +179,20 @@ export const analytics = {
 
   billPdfOpened: (billId: string) => capture('bill_pdf_opened', { bill_id: billId }),
 
+  billSaveToggled: (props: {
+    bill_id: string;
+    action: 'saved' | 'unsaved';
+    bill_type: string;
+    bill_number: string;
+    congress: number;
+    policy_area: string;
+    progress_stage: number | string;
+  }) => capture('bill_save_toggled', props),
+
+  /** Signed-out user clicked Save — the save-as-signup-driver conversion moment. */
+  billSaveSigninRedirected: (billId: string) =>
+    capture('bill_save_signin_redirected', { bill_id: billId }),
+
   billChatQuestionSubmitted: (props: {
     bill_id: string;
     question: string;


### PR DESCRIPTION
## What

First sub-project (A) of the account-platform roadmap: **saved bills**.

- **Save/Saved toggle** on every bill detail page, in the header next to the "Read full text (PDF)" link (`components/bills/save-bill-button.tsx`, wired in `components/bills/bill-details.tsx`).
- **"Saved bills" section on `/account`** — newest first, each row links back to its bill, with a fallback row if a bill ever disappears from the database (`app/account/page.tsx`).
- **Signed-out visitors see the button too**: clicking routes to `/sign-in?redirect=<bill page>` and back after auth — this is the feature's conversion moment.

## Backend (already live on prod Convex)

- New additive `savedBills` table: `userId`, `billId` (composite key string), `savedAt`; indexes `by_user` and `by_user_and_bill`. Nothing existing modified.
- `convex/savedBills.ts`: `isSaved` (returns `false` for anonymous, never throws), `toggleSave` (requires auth, validates the bill exists, insert/delete toggle), `listSaved` (bounded `.take(200)`, indexed point-read join to `bills`, `bill: null` kept for missing bills).
- Identity always derived server-side via `getAuthUserId`/`requireUser` — no client-supplied user ids.
- **Deployed to prod before this PR** (local dev has no separate Convex backend); the table is invisible to users until this UI ships.

## Analytics (per the ANALYTICS.md contract)

- `bill_save_toggled` — fired on each save/unsave with bill props; in-flight guard prevents double-counting from rapid clicks.
- `bill_save_signin_redirected` — fired when a signed-out user clicks Save (top of the save → signup funnel).
- Registered in `ANALYTICS.md`, typed helpers in `lib/analytics.ts`, no raw event strings.

## Reviewer notes

- Save is a **plain bookmark** by design — no notify flag; notifications come later via the weekly-email sub-project.
- Button placement is detail-page-only by design (not on bill cards).
- Optimistic update flips the label instantly; Convex auto-rolls-back on error. Double-clicks converge via mutation serialization.
- An Opus code-review pass found no critical/important issues; its two minor suggestions (in-flight click guard, pathname fallback) are included.

## Verification

- `npx convex deploy` clean (additive schema, no index deletions).
- `pnpm build` passes (TypeScript gate; repo has no ESLint).
- Manual flow to test: signed-out Save → sign-in → back on bill → Save → check `/account` → unsave → empty state; PostHog Activity shows both events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)