### PR TITLE
Add Terms of Service and Privacy Policy pages; fix contact email

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -57,7 +57,8 @@ These are enabled by `posthog.init` config in `instrumentation-client.ts`:
 | `$exception` | Uncaught JS errors and unhandled promise rejections (Error Tracking) |
 | Heatmaps | Click/move/scroll-depth maps per page (rendered from autocapture data) |
 
-Server-rendered pages with no interactivity (the About page) intentionally have **no custom
+Server-rendered pages with no interactivity (the About page and the legal pages — `/terms`,
+`/privacy`) intentionally have **no custom
 code** — their CTA clicks are captured by autocapture and tagged with
 `data-ph-capture-attribute-*` HTML attributes so they can be filtered in PostHog. The Learn
 page is interactive (civics guide) and fires its own custom events — see "Learn page" below.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ If you're not sure where to start, [open an issue](https://github.com/shreyashgu
 
 ## Questions or feedback
 
-Email **hi@mail.billsincongress.com** or open an issue on GitHub. Bills.Congress is a public-interest project — feedback from people outside the codebase is the most valuable kind.
+Email **hi@billsincongress.com** or open an issue on GitHub. Bills.Congress is a public-interest project — feedback from people outside the codebase is the most valuable kind.
 
 ## License
 

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -26,10 +26,10 @@ export default function ForgotPasswordPage() {
             <li>
               Email{" "}
               <a
-                href="mailto:hi@mail.billsincongress.com"
+                href="mailto:hi@billsincongress.com"
                 className="text-foreground underline"
               >
-                hi@mail.billsincongress.com
+                hi@billsincongress.com
               </a>{" "}
               and we&apos;ll reset it for you
             </li>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,405 @@
+import Link from 'next/link';
+import { sharedViewport } from '../shared-metadata';
+import type { Metadata, Viewport } from 'next';
+
+export const viewport: Viewport = sharedViewport;
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description:
+    'How Bills.Congress collects, uses, and protects your data — in plain English.',
+};
+
+const LAST_UPDATED = 'June 9, 2026';
+
+export default function PrivacyPage() {
+  return (
+    <article className="animate-fade-in">
+      <header className="border-b border-border">
+        <div className="container-editorial py-12 sm:py-16">
+          <p className="label-eyebrow mb-3">Legal</p>
+          <h1 className="font-serif text-display-md sm:text-display-lg font-semibold leading-[1.05] tracking-tight max-w-3xl">
+            Privacy Policy
+          </h1>
+          <p className="mt-5 max-w-2xl text-base sm:text-lg text-muted-foreground leading-relaxed">
+            We run this site to make Congress easier to read — not to collect
+            data about you. This page explains, in plain English, exactly what
+            we collect, why we collect it, and what we will never do with it.
+          </p>
+          <p className="mt-4 font-mono text-xs text-muted-foreground tabular">
+            Last updated: {LAST_UPDATED}
+          </p>
+        </div>
+      </header>
+
+      <section className="container-editorial py-14">
+        <div className="grid lg:grid-cols-12 gap-10 lg:gap-16">
+          <div className="lg:col-span-8 space-y-10">
+            <Section number={1} title="Who we are">
+              <p>
+                Bills.Congress (billsincongress.com) is an independent,
+                open-source, public-interest project operated by Shreyash
+                Gupta. It is not affiliated with the United States government.
+                The legislative data we publish comes from the official{' '}
+                <ExternalLink href="https://api.congress.gov">
+                  Congress.gov API
+                </ExternalLink>{' '}
+                and is in the public domain. In this policy, &ldquo;we&rdquo;
+                and &ldquo;us&rdquo; refer to the project and its operator.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={2} title="What we collect when you just browse">
+              <p>
+                You can read every bill on this site without creating an
+                account. While you browse, we collect usage analytics through{' '}
+                <ExternalLink href="https://posthog.com">PostHog</ExternalLink>
+                : the pages you visit, the links and buttons you click, your
+                browser and device type, the site that referred you, page
+                performance measurements, and any errors the site throws. Our
+                analytics also include session replay — a reconstruction of how
+                a page was used (clicks, scrolling, navigation) that helps us
+                find confusing design and bugs.
+              </p>
+              <p>
+                Your IP address is processed by our hosting provider
+                (Cloudflare) to deliver the site and protect it from abuse, and
+                by our analytics provider to estimate an approximate, city-level
+                location. We do not store IP addresses in our own database.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={3} title="The AI bill chat">
+              <p>
+                When you ask a question about a bill, your question — together
+                with the bill&rsquo;s public information (title, sponsor,
+                status, official summary) — is sent to{' '}
+                <ExternalLink href="https://groq.com">Groq</ExternalLink>, the
+                AI provider that generates the answer. Groq receives your
+                question text but not your name or email address.
+              </p>
+              <p>
+                We store chat questions and answers in our database. If you are
+                signed in, they are tied to your account so your conversation
+                history survives a refresh. If you are signed out, they are
+                keyed to a random identifier stored in a cookie on your device
+                — we have no way to connect them to who you are. Question text
+                is also included in our product analytics so we can understand
+                what people want to know about legislation.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={4} title="If you create an account">
+              <p>
+                Creating an account is optional. If you sign up with email and
+                password, we store your email address, a one-way encrypted
+                (hashed) version of your password — we never store or see the
+                password itself — and whether your email has been verified. If
+                you sign in with Google, we receive your name, email address,
+                and profile picture from Google; we never see your Google
+                password.
+              </p>
+              <p>
+                While you use your account, we also store the things you do
+                with it: the bills you save and your bill-chat history. Once
+                you are signed in, our analytics link your activity to your
+                account (including your email address) so we can understand the
+                journey from first visit to sign-up. We send email only for
+                account purposes — verification codes and password resets — via{' '}
+                <ExternalLink href="https://resend.com">Resend</ExternalLink>.
+                We do not send marketing email or newsletters.
+              </p>
+              <p>
+                The site is free and has no paid features today, so we do not
+                collect any payment information.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={5} title="Cookies and local storage">
+              <p>
+                We use a small number of cookies and browser-storage entries,
+                all of them functional — none are advertising trackers:
+              </p>
+              <ul className="space-y-3 mt-4">
+                {cookies.map((c) => (
+                  <li
+                    key={c.name}
+                    className="border-b border-border pb-3 last:border-0"
+                  >
+                    <p className="font-mono text-sm text-foreground">{c.name}</p>
+                    <p className="text-sm text-muted-foreground leading-relaxed mt-1">
+                      {c.purpose}{' '}
+                      <span className="text-foreground/70">({c.lifespan})</span>
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={6} title="The services we rely on">
+              <p>
+                We don&rsquo;t share your data with anyone except the service
+                providers that make the site run, and only to the extent needed
+                for the job each one does:
+              </p>
+              <ul className="space-y-3 mt-4">
+                {providers.map((p) => (
+                  <li
+                    key={p.name}
+                    className="border-b border-border pb-3 last:border-0"
+                  >
+                    <p className="font-serif text-base font-semibold tracking-tight">
+                      {p.name}
+                    </p>
+                    <p className="text-sm text-muted-foreground leading-relaxed mt-1">
+                      {p.role}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4">
+                All of these providers process data in the United States.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={7} title="What we never do">
+              <ul className="space-y-2 list-disc pl-5">
+                <li>We never sell or rent your data to anyone.</li>
+                <li>
+                  We show no ads and use no advertising trackers or data
+                  brokers.
+                </li>
+                <li>
+                  We don&rsquo;t share your data with third parties beyond the
+                  service providers listed above, unless the law requires it.
+                </li>
+                <li>
+                  We don&rsquo;t ask for — and don&rsquo;t want — any sensitive
+                  personal information.
+                </li>
+              </ul>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={8} title="How long we keep things">
+              <p>
+                Account data, saved bills, and signed-in chat history are kept
+                for as long as your account exists. Sign-in sessions expire
+                after at most 60 days of inactivity. Signed-out chat
+                conversations are keyed to a cookie that expires after 60 days.
+                Analytics data is retained by PostHog under its standard
+                retention policies.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={9} title="Your choices and rights">
+              <p>
+                You can read everything on this site without an account. You
+                can block or clear cookies at any time — the site keeps working
+                (you would be signed out, and analytics simply stops). You can
+                change your password through the password-reset flow.
+              </p>
+              <p>
+                To delete your account — along with your saved bills and chat
+                history — or to request a copy of the data we hold about you,
+                email{' '}
+                <a
+                  href="mailto:hi@mail.billsincongress.com"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  hi@mail.billsincongress.com
+                </a>{' '}
+                and we&rsquo;ll take care of it.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={10} title="Children">
+              <p>
+                The site is an educational resource that anyone can read, but
+                it is not directed at children under 13, and we ask that
+                children under 13 not create accounts.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={11} title="Changes to this policy">
+              <p>
+                If our data practices change, we will update this page and the
+                &ldquo;last updated&rdquo; date at the top. Because the project
+                is open source, the{' '}
+                <ExternalLink href="https://github.com/shreyashguptas/billsincongress">
+                  full history of this policy
+                </ExternalLink>{' '}
+                is publicly visible on GitHub.
+              </p>
+            </Section>
+          </div>
+
+          {/* Sidebar — plain-English summary */}
+          <aside className="lg:col-span-4">
+            <div className="lg:sticky lg:top-24 border-l border-border pl-6 space-y-6">
+              <div>
+                <p className="label-eyebrow mb-2">The short version</p>
+                <p className="font-serif text-xl font-semibold tracking-tight leading-tight">
+                  We collect as little as possible, and we never sell it.
+                </p>
+              </div>
+              <ul className="space-y-3 text-sm">
+                {summary.map((item) => (
+                  <li
+                    key={item}
+                    className="border-b border-border pb-2 text-muted-foreground leading-relaxed"
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Questions? Email{' '}
+                <a
+                  href="mailto:hi@mail.billsincongress.com"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  hi@mail.billsincongress.com
+                </a>
+                . See also our{' '}
+                <Link
+                  href="/terms"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  Terms of Service
+                </Link>
+                .
+              </p>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+function Section({
+  number,
+  title,
+  children,
+}: {
+  number: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <span className="col-span-12 sm:col-span-1 font-mono text-sm text-muted-foreground tabular pt-1">
+        {String(number).padStart(2, '0')}
+      </span>
+      <div className="col-span-12 sm:col-span-11">
+        <h2 className="font-serif text-display-sm font-semibold tracking-tight mb-3">
+          {title}
+        </h2>
+        <div className="space-y-4 text-base text-muted-foreground leading-relaxed">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ExternalLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-4 hover:text-foreground"
+    >
+      {children}
+    </a>
+  );
+}
+
+const summary = [
+  'We never sell your data. No ads, no ad trackers, no data brokers.',
+  'You can read every bill without an account.',
+  'An account is just an email and password (or Google sign-in) — nothing more.',
+  'AI chat questions are answered by Groq and stored so your conversation works; they are never tied to your identity unless you sign in.',
+  'We email you only for account reasons — never marketing.',
+  'No payment data: the site is free.',
+];
+
+const cookies = [
+  {
+    name: 'Sign-in session cookies',
+    purpose:
+      'Keep you signed in to your account so you don’t have to log in on every visit.',
+    lifespan: 'up to 60 days',
+  },
+  {
+    name: 'bic_bill_chat_session',
+    purpose:
+      'A random ID that enforces the daily AI-chat limit for signed-out visitors. Contains no personal information.',
+    lifespan: '60 days',
+  },
+  {
+    name: 'PostHog analytics (ph_*)',
+    purpose:
+      'Distinguishes one visitor from another so usage statistics are accurate.',
+    lifespan: 'up to 1 year',
+  },
+  {
+    name: 'Theme preference (local storage)',
+    purpose: 'Remembers your light/dark mode choice. Never leaves your browser.',
+    lifespan: 'until cleared',
+  },
+];
+
+const providers = [
+  {
+    name: 'Convex',
+    role: 'Our database and authentication backend. Stores accounts, saved bills, chat history, and the public bill data.',
+  },
+  {
+    name: 'Cloudflare',
+    role: 'Hosts and serves the website, and protects it from attacks. Processes IP addresses as part of delivering every request.',
+  },
+  {
+    name: 'PostHog',
+    role: 'Product analytics (US cloud): page views, clicks, session replay, performance, and error reports.',
+  },
+  {
+    name: 'Groq',
+    role: 'Generates the AI answers in bill chat. Receives your question and the bill’s public details — not your identity.',
+  },
+  {
+    name: 'Resend',
+    role: 'Delivers account emails: verification codes and password resets.',
+  },
+  {
+    name: 'Google',
+    role: 'Only if you choose “Sign in with Google”: provides us your name, email, and profile picture.',
+  },
+];

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     'How Bills.Congress collects, uses, and protects your data — in plain English.',
 };
 
-const LAST_UPDATED = 'June 9, 2026';
+const LAST_UPDATED = 'June 10, 2026';
 
 export default function PrivacyPage() {
   return (
@@ -219,10 +219,10 @@ export default function PrivacyPage() {
                 history — or to request a copy of the data we hold about you,
                 email{' '}
                 <a
-                  href="mailto:hi@mail.billsincongress.com"
+                  href="mailto:hi@billsincongress.com"
                   className="underline underline-offset-4 hover:text-foreground"
                 >
-                  hi@mail.billsincongress.com
+                  hi@billsincongress.com
                 </a>{' '}
                 and we&rsquo;ll take care of it.
               </p>
@@ -275,10 +275,10 @@ export default function PrivacyPage() {
               <p className="text-xs text-muted-foreground leading-relaxed">
                 Questions? Email{' '}
                 <a
-                  href="mailto:hi@mail.billsincongress.com"
+                  href="mailto:hi@billsincongress.com"
                   className="underline underline-offset-4 hover:text-foreground"
                 >
-                  hi@mail.billsincongress.com
+                  hi@billsincongress.com
                 </a>
                 . See also our{' '}
                 <Link

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,330 @@
+import Link from 'next/link';
+import { sharedViewport } from '../shared-metadata';
+import type { Metadata, Viewport } from 'next';
+
+export const viewport: Viewport = sharedViewport;
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+  description:
+    'The terms for using Bills.Congress — a free, independent record of legislation in the United States Congress.',
+};
+
+const LAST_UPDATED = 'June 9, 2026';
+
+export default function TermsPage() {
+  return (
+    <article className="animate-fade-in">
+      <header className="border-b border-border">
+        <div className="container-editorial py-12 sm:py-16">
+          <p className="label-eyebrow mb-3">Legal</p>
+          <h1 className="font-serif text-display-md sm:text-display-lg font-semibold leading-[1.05] tracking-tight max-w-3xl">
+            Terms of Service
+          </h1>
+          <p className="mt-5 max-w-2xl text-base sm:text-lg text-muted-foreground leading-relaxed">
+            Bills.Congress is a free, public-interest service. These terms keep
+            it that way — they are short, written in plain English, and ask
+            little more than that you use the site reasonably.
+          </p>
+          <p className="mt-4 font-mono text-xs text-muted-foreground tabular">
+            Last updated: {LAST_UPDATED}
+          </p>
+        </div>
+      </header>
+
+      <section className="container-editorial py-14">
+        <div className="grid lg:grid-cols-12 gap-10 lg:gap-16">
+          <div className="lg:col-span-8 space-y-10">
+            <Section number={1} title="Agreement to these terms">
+              <p>
+                Bills.Congress (billsincongress.com) is an independent,
+                open-source project operated by Shreyash Gupta. By using the
+                site, you agree to these terms. If you do not agree with them,
+                please do not use the site.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={2} title="What the service is (and isn't)">
+              <p>
+                The site reorganises public legislative data from the official{' '}
+                <ExternalLink href="https://api.congress.gov">
+                  Congress.gov API
+                </ExternalLink>{' '}
+                into a clearer, more readable record of the bills moving
+                through the United States Congress, and offers an AI assistant
+                that answers questions about individual bills.
+              </p>
+              <p>
+                Bills.Congress is <strong>not</strong> affiliated with,
+                endorsed by, or operated by the United States government. It is
+                an educational and informational resource — nothing on this
+                site is legal, financial, or professional advice. For official
+                purposes, always rely on{' '}
+                <ExternalLink href="https://www.congress.gov">
+                  Congress.gov
+                </ExternalLink>
+                .
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={3} title="Accuracy and AI-generated content">
+              <p>
+                We sync data from the public record daily and work hard to
+                present it faithfully, but data can lag behind events or
+                contain errors introduced upstream or by our processing.
+              </p>
+              <p>
+                Answers and summaries produced by the AI assistant are
+                generated automatically and can be incomplete, outdated, or
+                plainly wrong. They are a starting point for understanding a
+                bill — not a substitute for reading the bill itself or
+                consulting the official record.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={4} title="Your account">
+              <p>
+                You don&rsquo;t need an account to read the site. If you create
+                one — to save bills and get a higher AI-chat allowance — you
+                agree to provide accurate information, keep your password to
+                yourself, and be at least 13 years old. You are responsible for
+                activity that happens under your account.
+              </p>
+              <p>
+                You can stop using the site at any time, and you can have your
+                account and its data deleted by emailing{' '}
+                <a
+                  href="mailto:hi@mail.billsincongress.com"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  hi@mail.billsincongress.com
+                </a>
+                .
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={5} title="Fair use of the service">
+              <p>
+                The site is free, and the AI assistant costs real money to run,
+                so daily usage limits apply (shown in the app when you reach
+                them). To keep the service available for everyone, you agree
+                not to:
+              </p>
+              <ul className="space-y-2 list-disc pl-5">
+                <li>
+                  circumvent rate limits or access controls, or automate
+                  requests in a way that burdens the service;
+                </li>
+                <li>
+                  attempt to disrupt, overload, probe, or gain unauthorised
+                  access to the site or its infrastructure;
+                </li>
+                <li>use the service for anything unlawful; or</li>
+                <li>
+                  misrepresent AI-generated answers as official government
+                  statements.
+                </li>
+              </ul>
+              <p>
+                If you want the data in bulk, you don&rsquo;t need to scrape us
+                — it&rsquo;s all public at Congress.gov, and our code is open
+                source.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={6} title="Content and licenses">
+              <p>
+                The legislative data on this site comes from the United States
+                government and is in the public domain. The site&rsquo;s source
+                code is open source under the MIT license on{' '}
+                <ExternalLink href="https://github.com/shreyashguptas/billsincongress">
+                  GitHub
+                </ExternalLink>
+                . The Bills.Congress name and the site&rsquo;s presentation
+                remain ours.
+              </p>
+              <p>
+                When you submit a question to the AI assistant, you give us
+                permission to process and store it so the feature can work and
+                so we can improve the service, as described in our{' '}
+                <Link
+                  href="/privacy"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  Privacy Policy
+                </Link>
+                .
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={7} title="No warranty">
+              <p>
+                The service is provided &ldquo;as is&rdquo; and &ldquo;as
+                available,&rdquo; without warranties of any kind, express or
+                implied — including accuracy, availability, or fitness for a
+                particular purpose. We may change, suspend, or discontinue any
+                part of the service at any time.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={8} title="Limitation of liability">
+              <p>
+                To the fullest extent permitted by law, the project and its
+                operator are not liable for any indirect, incidental, or
+                consequential damages arising from your use of the site, or for
+                decisions made in reliance on its content — including
+                AI-generated content. The service is free; our total liability
+                for any claim is limited to the amount you paid to use it,
+                which is zero.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={9} title="Suspension and termination">
+              <p>
+                We may suspend or close accounts that violate these terms or
+                abuse the service. You may delete your account at any time as
+                described above.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={10} title="Changes to these terms">
+              <p>
+                If we change these terms, we will update this page and the
+                &ldquo;last updated&rdquo; date at the top. Continued use of
+                the site after a change means you accept the new terms. The{' '}
+                <ExternalLink href="https://github.com/shreyashguptas/billsincongress">
+                  full history of this page
+                </ExternalLink>{' '}
+                is publicly visible on GitHub.
+              </p>
+            </Section>
+
+            <div className="rule" />
+
+            <Section number={11} title="Governing law and contact">
+              <p>
+                These terms are governed by the laws of the United States.
+                Questions about them are welcome at{' '}
+                <a
+                  href="mailto:hi@mail.billsincongress.com"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  hi@mail.billsincongress.com
+                </a>{' '}
+                or on{' '}
+                <ExternalLink href="https://github.com/shreyashguptas/billsincongress">
+                  GitHub
+                </ExternalLink>
+                .
+              </p>
+            </Section>
+          </div>
+
+          {/* Sidebar — plain-English summary */}
+          <aside className="lg:col-span-4">
+            <div className="lg:sticky lg:top-24 border-l border-border pl-6 space-y-6">
+              <div>
+                <p className="label-eyebrow mb-2">The short version</p>
+                <p className="font-serif text-xl font-semibold tracking-tight leading-tight">
+                  A free public resource. Use it reasonably.
+                </p>
+              </div>
+              <ul className="space-y-3 text-sm">
+                {summary.map((item) => (
+                  <li
+                    key={item}
+                    className="border-b border-border pb-2 text-muted-foreground leading-relaxed"
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                How we handle data is covered separately in our{' '}
+                <Link
+                  href="/privacy"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  Privacy Policy
+                </Link>
+                .
+              </p>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+function Section({
+  number,
+  title,
+  children,
+}: {
+  number: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <span className="col-span-12 sm:col-span-1 font-mono text-sm text-muted-foreground tabular pt-1">
+        {String(number).padStart(2, '0')}
+      </span>
+      <div className="col-span-12 sm:col-span-11">
+        <h2 className="font-serif text-display-sm font-semibold tracking-tight mb-3">
+          {title}
+        </h2>
+        <div className="space-y-4 text-base text-muted-foreground leading-relaxed">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ExternalLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-4 hover:text-foreground"
+    >
+      {children}
+    </a>
+  );
+}
+
+const summary = [
+  'Free to use, with or without an account.',
+  'Not the government, and not legal advice — verify anything important on Congress.gov.',
+  'AI answers can be wrong. Read the bill.',
+  'Daily AI-chat limits keep the service free for everyone — don’t try to game them.',
+  'The data is public domain; the code is open source.',
+  'Provided as-is, no warranty.',
+];

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     'The terms for using Bills.Congress — a free, independent record of legislation in the United States Congress.',
 };
 
-const LAST_UPDATED = 'June 9, 2026';
+const LAST_UPDATED = 'June 10, 2026';
 
 export default function TermsPage() {
   return (
@@ -100,10 +100,10 @@ export default function TermsPage() {
                 You can stop using the site at any time, and you can have your
                 account and its data deleted by emailing{' '}
                 <a
-                  href="mailto:hi@mail.billsincongress.com"
+                  href="mailto:hi@billsincongress.com"
                   className="underline underline-offset-4 hover:text-foreground"
                 >
-                  hi@mail.billsincongress.com
+                  hi@billsincongress.com
                 </a>
                 .
               </p>
@@ -224,10 +224,10 @@ export default function TermsPage() {
                 These terms are governed by the laws of the United States.
                 Questions about them are welcome at{' '}
                 <a
-                  href="mailto:hi@mail.billsincongress.com"
+                  href="mailto:hi@billsincongress.com"
                   className="underline underline-offset-4 hover:text-foreground"
                 >
-                  hi@mail.billsincongress.com
+                  hi@billsincongress.com
                 </a>{' '}
                 or on{' '}
                 <ExternalLink href="https://github.com/shreyashguptas/billsincongress">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -54,6 +54,8 @@ export function Footer() {
                   Data: Congress.gov
                 </a>
               </li>
+              <li><Link href="/terms" className="text-muted-foreground hover:text-foreground">Terms of Service</Link></li>
+              <li><Link href="/privacy" className="text-muted-foreground hover:text-foreground">Privacy Policy</Link></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## What this does

Adds two new public legal pages and fixes a dead contact email across the site.

- **New `/terms` (Terms of Service)** and **`/privacy` (Privacy Policy)** pages, written in plain English and accurate to what the site actually does — not a boilerplate template. The privacy policy lists exactly what's collected (analytics via PostHog, AI chat questions sent to Groq, account email/hashed password or Google sign-in, saved bills, chat history) and states plainly: no data selling, no ads, no ad trackers, no payment info collected.
- Both pages follow the existing **editorial design** of the About page (eyebrow labels, serif display headings, numbered sections, sticky "short version" sidebar). Verified on desktop + mobile, light + dark mode.
- **Footer links** to both pages added under the Project column.
- **Contact email fixed everywhere** (`/terms`, `/privacy`, `/forgot-password`, and the README) from `hi@mail.billsincongress.com` → `hi@billsincongress.com`.

## Why the email changed

`hi@mail.billsincongress.com` is only a Resend *sender* identity — `mail.billsincongress.com` has no MX records, so mail sent **to** it bounced. It had been a dead contact link on the forgot-password page. **Cloudflare Email Routing** is now enabled on the `billsincongress.com` zone with a rule forwarding `hi@billsincongress.com` → the owner's verified personal inbox. End-to-end delivery confirmed (test email received). Outbound Resend sending records are untouched — automated verification/reset emails still send from the `mail.` sender as before.

## Analytics

These are static, server-rendered pages with no custom interactivity, so they rely on PostHog autocapture — no new tracked events. Noted in `ANALYTICS.md` per the project's analytics-registry convention.

## Reviewer notes

- The pages name the operator personally and make commitments on his behalf (handles deletion/data-export requests by email, 13+ age rule, U.S. governing law, "no payments / no marketing email"). These were reviewed and approved by the owner.
- **Future maintenance:** when paid plans or a newsletter launch, both pages must be updated — they currently promise no payment collection and no marketing email.
- No backend/schema changes; merging to `main` auto-deploys via the existing GitHub Actions pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
