### PR TITLE
Root-cause fix: index the incomplete-bills set so sync self-maintenance can't hit the read limit

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -26,6 +26,7 @@ import type * as mutations from "../mutations.js";
 import type * as rateLimits from "../rateLimits.js";
 import type * as savedBills from "../savedBills.js";
 import type * as sync from "../sync.js";
+import type * as syncStatus from "../syncStatus.js";
 import type * as users from "../users.js";
 
 import type {
@@ -53,6 +54,7 @@ declare const fullApi: ApiFromModules<{
   rateLimits: typeof rateLimits;
   savedBills: typeof savedBills;
   sync: typeof sync;
+  syncStatus: typeof syncStatus;
   users: typeof users;
 }>;
 

--- a/convex/congressApi.ts
+++ b/convex/congressApi.ts
@@ -1075,23 +1075,38 @@ const REPAIR_BATCH_SIZE = 20; // fewer bills per batch since we're targeted
 export const repairIncompleteBills = internalAction({
   args: {
     congress: v.optional(v.number()),
+    // Cursor into the by_syncedEndpoints incomplete range. Omitted/`null` starts
+    // a fresh drain from the top of the range (how the weekly cron + CLI call it).
+    cursor: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args): Promise<{ repaired: number; remaining: boolean }> => {
     const apiKey = process.env.CONGRESS_API_KEY;
     if (!apiKey) throw new Error("CONGRESS_API_KEY not configured");
 
-    // Get incomplete bills
-    const incompleteBills = await ctx.runQuery(internal.sync.getIncompleteBills, {
+    // Read ONE page of incomplete bills from the by_syncedEndpoints index range.
+    // Only incomplete bills are ever read (complete bills are skipped by the
+    // index), so this is safe no matter how large the bills table grows.
+    const page = await ctx.runQuery(internal.sync.getIncompleteBillsPage, {
+      cursor: args.cursor ?? null,
+      numItems: REPAIR_BATCH_SIZE,
       congress: args.congress,
-      limit: REPAIR_BATCH_SIZE,
     });
+    const incompleteBills = page.bills;
 
-    if (incompleteBills.length === 0) {
+    // Nothing left in the whole incomplete range → done.
+    if (incompleteBills.length === 0 && page.isDone) {
       console.log("No incomplete bills to repair");
       return { repaired: 0, remaining: false };
     }
 
-    console.log(`Repairing ${incompleteBills.length} incomplete bills...`);
+    // Always log page progress (incl. congress scope) so a multi-page drain is
+    // observable — a congress-filtered page can legitimately be empty while more
+    // pages remain, and silent empty reschedules are hard to debug in prod.
+    const scope = args.congress !== undefined ? ` (congress ${args.congress})` : "";
+    console.log(
+      `Repair page${scope}: ${incompleteBills.length} incomplete bills to process` +
+        (page.isDone ? " (last page)" : ""),
+    );
     let repairedCount = 0;
     let consecutiveFailures = 0;
 
@@ -1292,15 +1307,25 @@ export const repairIncompleteBills = internalAction({
 
     console.log(`Repair batch complete: ${repairedCount} bills processed`);
 
-    // Self-schedule if more incomplete bills likely remain
-    if (incompleteBills.length >= REPAIR_BATCH_SIZE && consecutiveFailures < CONSECUTIVE_FAIL_LIMIT) {
-      await ctx.scheduler.runAfter(10000, internal.congressApi.repairIncompleteBills, {
-        congress: args.congress,
-      });
-      console.log("Scheduled next repair batch");
+    // Advance through the incomplete range by cursor until it's exhausted, as
+    // long as the circuit breaker hasn't tripped. When the range is drained
+    // (page.isDone) we stop — next week's cron starts a fresh drain from the top.
+    const moreToScan =
+      !page.isDone && consecutiveFailures < CONSECUTIVE_FAIL_LIMIT;
+    if (moreToScan) {
+      await ctx.scheduler.runAfter(
+        10000,
+        internal.congressApi.repairIncompleteBills,
+        { congress: args.congress, cursor: page.continueCursor },
+      );
+      console.log("Scheduled next repair page");
     }
 
-    return { repaired: repairedCount, remaining: incompleteBills.length >= REPAIR_BATCH_SIZE };
+    // `remaining` means "more pages of the incomplete index remain to scan"
+    // (not "more bills still need repair"): with a congress filter it can be true
+    // while zero bills for that congress remain. Callers (CLI/cron) treat it as a
+    // progress signal only.
+    return { repaired: repairedCount, remaining: !page.isDone };
   },
 });
 

--- a/convex/congressApi.ts
+++ b/convex/congressApi.ts
@@ -1329,57 +1329,6 @@ export const repairIncompleteBills = internalAction({
   },
 });
 
-const BACKFILL_BATCH_SIZE = 200;
-
-/**
- * One-time backfill: compute syncedEndpoints for existing bills by inspecting sub-tables.
- * No API calls — purely DB reads. Self-schedules in batches.
- */
-export const backfillSyncStatus = internalAction({
-  args: {
-    congress: v.optional(v.number()),
-  },
-  handler: async (ctx, args): Promise<{ processed: number; remaining: boolean }> => {
-    // Get legacy bills (syncedEndpoints undefined)
-    const toBackfill = await ctx.runQuery(internal.sync.getIncompleteBills, {
-      congress: args.congress,
-      limit: BACKFILL_BATCH_SIZE,
-      legacyOnly: true,
-    });
-
-    if (toBackfill.length === 0) {
-      console.log("No legacy bills to backfill");
-      return { processed: 0, remaining: false };
-    }
-
-    console.log(`Backfilling sync status for ${toBackfill.length} legacy bills...`);
-
-    for (const bill of toBackfill) {
-      const completeness = await ctx.runQuery(internal.sync.checkBillCompleteness, {
-        billId: bill.billId,
-      });
-
-      await ctx.runMutation(internal.mutations.updateBillSyncStatus, {
-        billId: bill.billId,
-        endpointBits: completeness.syncedEndpoints,
-        lastSyncAttempt: new Date().toISOString(),
-      });
-    }
-
-    console.log(`Backfilled ${toBackfill.length} bills`);
-
-    // Self-schedule if more remain
-    if (toBackfill.length >= BACKFILL_BATCH_SIZE) {
-      await ctx.scheduler.runAfter(2000, internal.congressApi.backfillSyncStatus, {
-        congress: args.congress,
-      });
-      console.log("Scheduled next backfill batch");
-    }
-
-    return { processed: toBackfill.length, remaining: toBackfill.length >= BACKFILL_BATCH_SIZE };
-  },
-});
-
 const STAGE_BACKFILL_PAGE = 40; // bills per mutation (≤250 actions each → read-limit safe)
 const STAGE_BACKFILL_BILLS_PER_RUN = 5000; // bills per invocation before self-scheduling
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -115,6 +115,11 @@ export default defineSchema({
     .index("by_progress_stage", ["progressStage"])
     .index("by_sponsor_state", ["sponsorState"])
     .index("by_updated_at", ["updatedAt"])
+    // Lets the repair job + completeness diagnostic find INCOMPLETE bills via a
+    // range scan (syncedEndpoints < 31) instead of scanning the whole table.
+    // Convex orders undefined < numbers, so the range also returns legacy bills
+    // (field missing). Complete bills (31) are never read.
+    .index("by_syncedEndpoints", ["syncedEndpoints"])
     .searchIndex("search_title", {
       searchField: "title",
       filterFields: ["congress", "billType", "progressStage", "sponsorState"],

--- a/convex/sync.ts
+++ b/convex/sync.ts
@@ -27,59 +27,9 @@ export {
 } from "./syncStatus";
 
 /**
- * Returns bills where syncedEndpoints is undefined or < SYNC_COMPLETE.
- * Accepts optional congress filter and limit.
- */
-export const getIncompleteBills = internalQuery({
-  args: {
-    congress: v.optional(v.number()),
-    limit: v.optional(v.number()),
-    legacyOnly: v.optional(v.boolean()),
-  },
-  handler: async (ctx, args) => {
-    const limit = args.limit || 100;
-    const legacyOnly = args.legacyOnly || false;
-
-    let billsQuery;
-    if (args.congress !== undefined) {
-      billsQuery = ctx.db
-        .query("bills")
-        .withIndex("by_congress", (q) => q.eq("congress", args.congress!));
-    } else {
-      billsQuery = ctx.db.query("bills");
-    }
-
-    const allBills = await billsQuery.collect();
-    const incomplete = [];
-
-    for (const bill of allBills) {
-      if (incomplete.length >= limit) break;
-
-      const isLegacy = bill.syncedEndpoints === undefined;
-      if (legacyOnly && !isLegacy) continue;
-
-      if (isLegacy || bill.syncedEndpoints! < SYNC_COMPLETE) {
-        const mask = bill.syncedEndpoints || 0;
-        incomplete.push({
-          _id: bill._id,
-          billId: bill.billId,
-          congress: bill.congress,
-          billType: bill.billType,
-          billNumber: bill.billNumber,
-          syncedEndpoints: bill.syncedEndpoints,
-          missingEndpoints: getMissingEndpoints(mask),
-          isLegacy,
-        });
-      }
-    }
-
-    return incomplete;
-  },
-});
-
-/**
  * For a single bill, checks all 4 sub-tables for existence and returns a computed bitmask.
- * Used by the backfill action for legacy bills that have no syncedEndpoints value.
+ * Used by the repair path to derive the bitmask for legacy bills that have no
+ * syncedEndpoints value (the `isLegacy` branch of repairIncompleteBills).
  */
 export const checkBillCompleteness = internalQuery({
   args: {

--- a/convex/sync.ts
+++ b/convex/sync.ts
@@ -170,57 +170,57 @@ export const getIncompleteBillsPage = internalQuery({
   },
 });
 
+const COMPLETENESS_SCAN_CAP = 4000; // safety bound on incomplete rows read
+
 /**
- * Aggregate stats: total bills, complete, partial, legacy (undefined).
- * Internal-only — anyone-callable would let an unauthenticated visitor
- * trigger a full bills-table scan (~40k docs) on demand. No client
- * surface uses this; invoke from the CLI for ad-hoc audits:
- *   npx convex run sync:getSyncCompleteness '{}'
+ * Completeness diagnostic. Counts INCOMPLETE bills via the by_syncedEndpoints
+ * index range (legacy + partial) — so it reads only the incomplete set (a
+ * healthy table reads ~0 rows). `total` comes from the precomputed congressStats
+ * table (no bills scan); complete = total - incomplete. `truncated` is true if
+ * the incomplete set exceeded the safety cap (signals something is badly wrong).
+ *
+ * Internal-only; CLI:  npx convex run sync:getSyncCompleteness '{}'
  */
 export const getSyncCompleteness = internalQuery({
   args: {
     congress: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    // If congress is specified, query just that congress
-    // Otherwise, aggregate across all known congresses to avoid full table scan
-    const congressesToCheck: number[] = [];
+    const incomplete = await ctx.db
+      .query("bills")
+      .withIndex("by_syncedEndpoints", (q) =>
+        q.lt("syncedEndpoints", SYNC_COMPLETE),
+      )
+      .take(COMPLETENESS_SCAN_CAP);
 
-    if (args.congress !== undefined) {
-      congressesToCheck.push(args.congress);
-    } else {
-      for (let c = 93; c <= 120; c++) {
-        const bill = await ctx.db
-          .query("bills")
-          .withIndex("by_congress", (q) => q.eq("congress", c))
-          .first();
-        if (bill) congressesToCheck.push(c);
-      }
-    }
-
-    let total = 0;
-    let complete = 0;
     let partial = 0;
     let legacy = 0;
-
-    for (const congress of congressesToCheck) {
-      const bills = await ctx.db
-        .query("bills")
-        .withIndex("by_congress", (q) => q.eq("congress", congress))
-        .collect();
-
-      for (const bill of bills) {
-        total++;
-        if (bill.syncedEndpoints === undefined) {
-          legacy++;
-        } else if (bill.syncedEndpoints >= SYNC_COMPLETE) {
-          complete++;
-        } else {
-          partial++;
-        }
-      }
+    for (const b of incomplete) {
+      if (args.congress !== undefined && b.congress !== args.congress) continue;
+      if (classifySyncState(b.syncedEndpoints) === "legacy") legacy++;
+      else partial++;
     }
 
-    return { total, complete, partial, legacy };
+    // total from precomputed stats — never scans the bills table
+    let total = 0;
+    if (args.congress !== undefined) {
+      const row = await ctx.db
+        .query("congressStats")
+        .withIndex("by_congress", (q) => q.eq("congress", args.congress!))
+        .first();
+      total = row?.totalCount ?? 0;
+    } else {
+      const stats = await ctx.db.query("congressStats").collect();
+      total = stats.reduce((sum, s) => sum + s.totalCount, 0);
+    }
+
+    const incompleteCount = partial + legacy;
+    return {
+      total,
+      complete: Math.max(0, total - incompleteCount),
+      partial,
+      legacy,
+      truncated: incomplete.length >= COMPLETENESS_SCAN_CAP,
+    };
   },
 });

--- a/convex/sync.ts
+++ b/convex/sync.ts
@@ -1,38 +1,30 @@
 import { internalQuery } from "./_generated/server";
 import { v } from "convex/values";
+import {
+  SYNC_DETAIL,
+  SYNC_ACTIONS,
+  SYNC_SUBJECTS,
+  SYNC_SUMMARIES,
+  SYNC_TEXT,
+  SYNC_COMPLETE,
+  getMissingEndpoints,
+  classifySyncState,
+} from "./syncStatus";
 
-// Bitmask constants for endpoint tracking
-export const SYNC_DETAIL = 1; // bit 0
-export const SYNC_ACTIONS = 2; // bit 1
-export const SYNC_SUBJECTS = 4; // bit 2
-export const SYNC_SUMMARIES = 8; // bit 3
-export const SYNC_TEXT = 16; // bit 4
-export const SYNC_COMPLETE = 31; // all bits set
-
-// Enrichment bitmask (bills.extraSyncedBits) — kept SEPARATE from the endpoint
-// bitmask above so the repair / SYNC_COMPLETE flow is untouched. Tracks the
-// richer data that the original sync fetched but discarded.
-export const EXTRA_LEGISLATIVE_SUBJECTS = 1; // bit 0: all legislativeSubjects stored
-export const EXTRA_TEXT_VERSIONS = 2; // bit 1: all text versions stored
-export const EXTRA_COMPLETE = 3; // all enrichment bits set
-
-const ENDPOINT_NAMES: Record<number, string> = {
-  [SYNC_DETAIL]: "detail",
-  [SYNC_ACTIONS]: "actions",
-  [SYNC_SUBJECTS]: "subjects",
-  [SYNC_SUMMARIES]: "summaries",
-  [SYNC_TEXT]: "text",
-};
-
-function getMissingEndpoints(mask: number): string[] {
-  const missing: string[] = [];
-  for (const [bit, name] of Object.entries(ENDPOINT_NAMES)) {
-    if ((mask & Number(bit)) === 0) {
-      missing.push(name);
-    }
-  }
-  return missing;
-}
+// Re-export the bitmask constants + helpers so existing importers
+// (congressApi.ts, audit.ts) keep importing them from "./sync" unchanged.
+export {
+  SYNC_DETAIL,
+  SYNC_ACTIONS,
+  SYNC_SUBJECTS,
+  SYNC_SUMMARIES,
+  SYNC_TEXT,
+  SYNC_COMPLETE,
+  EXTRA_LEGISLATIVE_SUBJECTS,
+  EXTRA_TEXT_VERSIONS,
+  EXTRA_COMPLETE,
+  getMissingEndpoints,
+} from "./syncStatus";
 
 /**
  * Returns bills where syncedEndpoints is undefined or < SYNC_COMPLETE.

--- a/convex/sync.ts
+++ b/convex/sync.ts
@@ -123,6 +123,54 @@ export const checkBillCompleteness = internalQuery({
 });
 
 /**
+ * One page of INCOMPLETE bills (legacy or partial), found via the
+ * by_syncedEndpoints index range. Convex orders `undefined` before all numbers,
+ * so `.lt(SYNC_COMPLETE)` returns legacy (field missing) AND partial (0..30)
+ * bills while complete bills (>=31) are never read — a healthy table reads ZERO
+ * rows here regardless of size. This is what makes the repair job immune to the
+ * per-query read limit.
+ *
+ * Optional `congress` filters the (already tiny) page in memory, avoiding a
+ * second compound index.
+ */
+export const getIncompleteBillsPage = internalQuery({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+    congress: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("bills")
+      .withIndex("by_syncedEndpoints", (q) =>
+        q.lt("syncedEndpoints", SYNC_COMPLETE),
+      )
+      .paginate({ cursor: args.cursor, numItems: args.numItems });
+
+    const bills = page.page
+      .filter(
+        (b) => args.congress === undefined || b.congress === args.congress,
+      )
+      .map((b) => ({
+        _id: b._id,
+        billId: b.billId,
+        congress: b.congress,
+        billType: b.billType,
+        billNumber: b.billNumber,
+        syncedEndpoints: b.syncedEndpoints,
+        missingEndpoints: getMissingEndpoints(b.syncedEndpoints ?? 0),
+        isLegacy: b.syncedEndpoints === undefined,
+      }));
+
+    return {
+      bills,
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+    };
+  },
+});
+
+/**
  * Aggregate stats: total bills, complete, partial, legacy (undefined).
  * Internal-only — anyone-callable would let an unauthenticated visitor
  * trigger a full bills-table scan (~40k docs) on demand. No client

--- a/convex/syncStatus.test.ts
+++ b/convex/syncStatus.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the pure sync-status classifier. Mirrors billStage.test.ts:
+ * node:assert, no framework. Run via `pnpm test`.
+ */
+import assert from "node:assert/strict";
+import {
+  classifySyncState,
+  isIncompleteMask,
+  getMissingEndpoints,
+  SYNC_TEXT,
+  SYNC_COMPLETE,
+} from "./syncStatus";
+
+let passed = 0;
+const failures: string[] = [];
+function it(name: string, fn: () => void) {
+  try {
+    fn();
+    passed++;
+  } catch (err) {
+    failures.push(
+      `  ✗ ${name}\n    ${err instanceof Error ? err.message.split("\n").join("\n    ") : String(err)}`,
+    );
+  }
+}
+
+it("classifies undefined as legacy", () => {
+  assert.equal(classifySyncState(undefined), "legacy");
+});
+
+it("classifies the full mask (31) as complete", () => {
+  assert.equal(classifySyncState(SYNC_COMPLETE), "complete");
+});
+
+it("classifies a mask above complete as complete", () => {
+  assert.equal(classifySyncState(63), "complete");
+});
+
+it("classifies 0 as partial", () => {
+  assert.equal(classifySyncState(0), "partial");
+});
+
+it("classifies 30 (one bit short) as partial", () => {
+  assert.equal(classifySyncState(SYNC_COMPLETE - 1), "partial");
+});
+
+it("isIncompleteMask: undefined + partial are incomplete, complete is not", () => {
+  assert.equal(isIncompleteMask(undefined), true);
+  assert.equal(isIncompleteMask(0), true);
+  assert.equal(isIncompleteMask(SYNC_COMPLETE - 1), true);
+  assert.equal(isIncompleteMask(SYNC_COMPLETE), false);
+});
+
+it("getMissingEndpoints lists all five for an empty mask", () => {
+  assert.deepEqual(
+    getMissingEndpoints(0).sort(),
+    ["actions", "detail", "subjects", "summaries", "text"].sort(),
+  );
+});
+
+it("getMissingEndpoints returns nothing for a complete mask", () => {
+  assert.deepEqual(getMissingEndpoints(SYNC_COMPLETE), []);
+});
+
+it("getMissingEndpoints reports only the one missing bit", () => {
+  assert.deepEqual(getMissingEndpoints(SYNC_COMPLETE & ~SYNC_TEXT), ["text"]);
+});
+
+if (failures.length > 0) {
+  console.error(`\nsyncStatus: ${passed} passed, ${failures.length} FAILED\n`);
+  console.error(failures.join("\n\n"));
+  process.exit(1);
+}
+console.log(`syncStatus: all ${passed} tests passed`);

--- a/convex/syncStatus.ts
+++ b/convex/syncStatus.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure, dependency-free sync-status helpers. NO Convex imports, so this module
+ * is unit-testable under plain `tsx` (see syncStatus.test.ts) and safe to share
+ * between Convex functions (sync.ts, congressApi.ts, audit.ts).
+ */
+
+// Bitmask constants for endpoint tracking
+export const SYNC_DETAIL = 1; // bit 0
+export const SYNC_ACTIONS = 2; // bit 1
+export const SYNC_SUBJECTS = 4; // bit 2
+export const SYNC_SUMMARIES = 8; // bit 3
+export const SYNC_TEXT = 16; // bit 4
+export const SYNC_COMPLETE = 31; // all endpoint bits set
+
+// Enrichment bitmask (bills.extraSyncedBits) — kept SEPARATE from the endpoint
+// bitmask above so the repair / SYNC_COMPLETE flow is untouched.
+export const EXTRA_LEGISLATIVE_SUBJECTS = 1; // bit 0: all legislativeSubjects stored
+export const EXTRA_TEXT_VERSIONS = 2; // bit 1: all text versions stored
+export const EXTRA_COMPLETE = 3; // all enrichment bits set
+
+const ENDPOINT_NAMES: Record<number, string> = {
+  [SYNC_DETAIL]: "detail",
+  [SYNC_ACTIONS]: "actions",
+  [SYNC_SUBJECTS]: "subjects",
+  [SYNC_SUMMARIES]: "summaries",
+  [SYNC_TEXT]: "text",
+};
+
+export function getMissingEndpoints(mask: number): string[] {
+  const missing: string[] = [];
+  for (const [bit, name] of Object.entries(ENDPOINT_NAMES)) {
+    if ((mask & Number(bit)) === 0) missing.push(name);
+  }
+  return missing;
+}
+
+export type SyncState = "complete" | "partial" | "legacy";
+
+/**
+ * Classify a bill's sync status from its stored bitmask:
+ *   - undefined → "legacy"   (no syncedEndpoints field: pre-field bill, or a
+ *                             freshly inserted bill not yet sub-synced)
+ *   - >= 31     → "complete"
+ *   - 0..30     → "partial"
+ *
+ * Mirrors the index range used to FIND incomplete bills: because Convex orders
+ * `undefined` before all numbers, `.lt("syncedEndpoints", SYNC_COMPLETE)`
+ * returns exactly the rows this classifies as NOT "complete".
+ */
+export function classifySyncState(
+  syncedEndpoints: number | undefined,
+): SyncState {
+  if (syncedEndpoints === undefined) return "legacy";
+  if (syncedEndpoints >= SYNC_COMPLETE) return "complete";
+  return "partial";
+}
+
+/** True when a bill still needs repair (legacy or partial). */
+export function isIncompleteMask(syncedEndpoints: number | undefined): boolean {
+  return classifySyncState(syncedEndpoints) !== "complete";
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "generate-icons": "tsx scripts/generate-icons.ts",
     "optimize-images": "tsx scripts/optimize-images.ts",
-    "test": "tsx convex/billStage.test.ts",
+    "test": "tsx convex/billStage.test.ts && tsx convex/syncStatus.test.ts",
     "cf:build": "pnpm generate-icons && opennextjs-cloudflare build",
     "preview": "pnpm cf:build && opennextjs-cloudflare preview",
     "deploy": "pnpm cf:build && opennextjs-cloudflare deploy",


### PR DESCRIPTION
## What & why

The bills "self-maintenance" routines (the weekly auto-repair cron and the CLI completeness diagnostic) crashed at runtime because they loaded the **entire `bills` table** (~54k rows) into memory via `.collect()`, exceeding Convex's per-query read limit (16 MB). The weekly repair safety-net had therefore been silently failing.

This is a **root-cause fix**, not a band-aid: "incomplete bills" is now a directly-queryable set via a new index, so the routines read **only the incomplete bills** (a healthy table reads ~0 rows) and stay flat in cost as the table grows. No bill data is touched.

## How

- **New `by_syncedEndpoints` index** on `bills`. Convex orders `undefined < numbers`, so the range `syncedEndpoints < 31` returns both legacy (field absent) and partial (0–30) bills, and never reads complete bills (31).
- **`repairIncompleteBills`** (weekly cron) now reads one page of incomplete bills via the new `getIncompleteBillsPage` query and self-schedules by cursor until the range is drained. Per-bill repair body + circuit breaker unchanged.
- **`getSyncCompleteness`** (CLI diagnostic) counts the incomplete set via the index (capped) and gets the total from the precomputed `congressStats` table — no bills scan.
- **Deleted** the old full-table `getIncompleteBills` query and the now-obsolete `backfillSyncStatus` action — the scan anti-pattern is removed, not patched.
- Extracted the bitmask constants + classifier into a pure, unit-tested `convex/syncStatus.ts`.

## Verification

- `pnpm test` — 22 passing (13 existing + 9 new for the classifier).
- `pnpm build` — passes. `convex codegen` — clean.
- Independent branch review: **safe to deploy**, zero Critical/Important findings. Stress-tested the two hardest risks and confirmed both correct:
  - The index range catches legacy (pre-tracking) bills, not just partial ones.
  - Repairing a bill mid-scan (moving it out of range) cannot skip un-repaired bills — Convex cursors are absolute index-key positions, not offsets.

## Deploy note ⚠️

**Backend-only change — merging this PR does NOT deploy it.** Pushing to `main` auto-deploys the *website* only; the Convex backend (incl. building the new index) must be deployed manually via `npx convex deploy`. Because all workspaces share one prod Convex deployment, **merge `origin/main` into the deploying branch first** to avoid clobbering other merged features.

No user-facing changes → no `ANALYTICS.md` / `lib/analytics.ts` updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
