### PR TITLE
Add Dataset schema + enrich Legislation markup

### DIFF
--- a/app/bills/[id]/page.tsx
+++ b/app/bills/[id]/page.tsx
@@ -35,6 +35,7 @@ function billJsonLd(bill: Bill, id: string): object {
     name: bill.title,
     legislationIdentifier: identifier,
     legislationType: legislationTypeLabel(bill.bill_type),
+    legislationJurisdiction: 'United States',
     inLanguage: 'en',
     isPartOf: { '@id': `${SITE_URL}/#website` },
   };
@@ -57,9 +58,12 @@ function billJsonLd(bill: Bill, id: string): object {
       name: 'United States Congress',
     };
   }
-  if (bill.progress_stage === 100) {
-    legislation.legislationLegalForce = 'https://schema.org/InForce';
-  }
+  // Signed-into-law bills are in force; everything still moving (introduced, in
+  // committee, passed one/both chambers) has no legal force yet.
+  legislation.legislationLegalForce =
+    bill.progress_stage === 100
+      ? 'https://schema.org/InForce'
+      : 'https://schema.org/NotInForce';
   if (officialUrl) {
     legislation.sameAs = officialUrl;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,51 @@ const SITE_GRAPH = {
         'query-input': 'required name=search_term_string',
       },
     },
+    {
+      // Declares the whole bill corpus as a structured dataset — eligible for
+      // Google Dataset Search and a strong "authoritative data source" signal.
+      // `creator` is the data's origin (U.S. Congress); `publisher` is us, the
+      // aggregator. Data are U.S. Government works (public domain), sourced from
+      // Congress.gov. A real `distribution` (DataDownload) can be added later if a
+      // public data export / API ships.
+      '@type': 'Dataset',
+      '@id': `${SITE_URL}/#dataset`,
+      name: 'United States Congressional Bills',
+      description:
+        'A structured, continually updated record of every bill introduced in the United States Congress — including sponsor, current status and legislative stage, full text, subjects, and complete action history — covering recent Congresses. Sourced from the official Congress.gov API.',
+      url: `${SITE_URL}/bills`,
+      keywords: [
+        'United States Congress',
+        'legislation',
+        'bills',
+        'lawmaking',
+        'Congress.gov',
+        'legislative tracking',
+      ],
+      isAccessibleForFree: true,
+      creator: {
+        '@type': 'GovernmentOrganization',
+        name: 'United States Congress',
+        url: 'https://www.congress.gov',
+      },
+      publisher: { '@id': `${SITE_URL}/#org` },
+      isBasedOn: 'https://api.congress.gov',
+      sameAs: 'https://www.congress.gov',
+      creditText:
+        'Bill data are U.S. Government works (public domain), sourced from Congress.gov.',
+      license: 'https://creativecommons.org/publicdomain/mark/1.0/',
+      spatialCoverage: { '@type': 'Place', name: 'United States' },
+      temporalCoverage: '2021-01-03/..',
+      variableMeasured: [
+        'bill title',
+        'sponsor',
+        'legislative status',
+        'progress stage',
+        'policy area',
+        'actions',
+        'full text',
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
Declares the bill corpus as a schema.org Dataset (Google Dataset Search eligibility + authoritative-source signal) and enriches each bill's Legislation node with jurisdiction and explicit legal-force status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)