### PR TITLE
Enable Smart Placement and a per-request CPU guardrail

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,17 @@
   "observability": {
     "enabled": true
   },
+  // Run the Worker close to Convex (a single-region backend) to cut the latency
+  // of the server-side Convex round-trips made on most dynamic pages. mode
+  // "smart" is correct for a managed backend whose region we don't pin; Cloudflare
+  // only relocates the Worker when it measures a benefit.
+  "placement": { "mode": "smart" },
+  // Cost guardrail: cap CPU time per request so a runaway bug can't quietly run
+  // up the bill. 10s is ~30-100x a normal render and well under Cloudflare's 30s
+  // default. CPU time excludes time spent waiting on Convex/Resend/PostHog
+  // subrequests, so this does not affect normal traffic. Enforced on Cloudflare's
+  // network only, not in local dev.
+  "limits": { "cpu_ms": 10000 },
   "kv_namespaces": [
     { "binding": "NEXT_INC_CACHE_KV", "id": "27119da2bbef43b0b8a73deb425772a5" },
     { "binding": "NEXT_TAG_CACHE_KV", "id": "b0bc643509234dbb823721087525d9f7" }


### PR DESCRIPTION
## What

Two `wrangler.jsonc` settings now that we're on the Workers Paid plan:

- **`placement: { mode: "smart" }`** — The Worker makes server-side Convex round-trips on most dynamic pages (homepage fires 4 queries/load, `/bills` 3+, bill detail 1, sitemaps 7–8, plus the chat API routes). Smart Placement runs the Worker closer to Convex's single region to cut SSR latency. Cloudflare only relocates when it measures a benefit, so the downside is effectively nil.
- **`limits: { cpu_ms: 10000 }`** — Cost guardrail capping CPU time per request so a runaway bug can't quietly run up the bill. 10s is ~30–100× a normal render and well under Cloudflare's 30s default. CPU time excludes time spent waiting on Convex/Resend/PostHog subrequests, so normal traffic is unaffected.

Config-only — no application behavior change, no analytics impact.

## Verification

- `pnpm test` — 22 tests pass
- `pnpm build` — passes (includes lint)
- `npx wrangler deploy --dry-run` — config parses, bindings resolve

## Notes

- Both settings are enforced on Cloudflare's network only, not local dev.
- Smart Placement warms up: it relocates after observing real production traffic, not instantly on deploy.
- After merge (auto-deploys via GitHub Actions), confirm in the Cloudflare dashboard: CPU limit shows 10000 ms, and Placement status progresses to **Active**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)