### PR TITLE
Fix bill number search bypassing 1,200-doc scan cap

### DIFF
--- a/convex/bills.ts
+++ b/convex/bills.ts
@@ -503,6 +503,36 @@ export const list = query({
     const { matchesNone, match } = await buildBillPredicate(ctx, args);
     if (matchesNone) return { data: [], hasMore: false };
 
+    // Fast path: bill number is an exact indexed lookup — skip the scan cap entirely.
+    // A congress typically has at most ~8 bills with the same number (one per bill type),
+    // so collect() is safe here.
+    if (args.billNumber) {
+      const hits = await ctx.db
+        .query("bills")
+        .withIndex("by_congress_and_bill_number", (q) =>
+          q.eq("congress", congressFilter).eq("billNumber", args.billNumber!)
+        )
+        .collect();
+      const filtered = hits.filter(match);
+      const hasMore = filtered.length > offset + limit;
+      const page = filtered.slice(offset, offset + limit);
+      const enrichedPage = await Promise.all(
+        page.map(async (bill) => {
+          const subject = await ctx.db
+            .query("billSubjects")
+            .withIndex("by_billId", (q) => q.eq("billId", bill.billId))
+            .first();
+          return {
+            ...bill,
+            bill_subjects: subject
+              ? { policy_area_name: subject.policyAreaName || "" }
+              : { policy_area_name: "" },
+          };
+        })
+      );
+      return { data: enrichedPage, hasMore };
+    }
+
     const needed = offset + limit + 1;
     const matches: Doc<"bills">[] = [];
     let scanned = 0;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -120,6 +120,7 @@ export default defineSchema({
     // Convex orders undefined < numbers, so the range also returns legacy bills
     // (field missing). Complete bills (31) are never read.
     .index("by_syncedEndpoints", ["syncedEndpoints"])
+    .index("by_congress_and_bill_number", ["congress", "billNumber"])
     .searchIndex("search_title", {
       searchField: "title",
       filterFields: ["congress", "billType", "progressStage", "sponsorState"],


### PR DESCRIPTION
## What

Bill-number search on the All Bills page silently failed for most bills. Searching for a low or older bill number (e.g. HR 1, HR 5) returned nothing even though the bill existed.

## Why

`bills.list` streams the `by_congress` index in insertion order (newest first) and stops after scanning 1,200 docs. A congress has ~19K+ bills, so bills inserted in earlier syncs — which includes most low-numbered and older bills — sit far past the scan cap and were never reached. This is why search "sometimes worked": only recently-synced bill numbers fell inside the window.

## Fix

- New `by_congress_and_bill_number` index on the `bills` table.
- Fast-path in `bills.list`: when a bill number is provided, do a direct indexed lookup instead of the capped scan. O(~8) regardless of congress size (at most one bill per bill type shares a number).

## Deploy note

The Convex backend portion was already deployed to production (`industrious-llama-331`) to fix the live bug immediately. This PR carries the matching source commit into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)